### PR TITLE
fix: update release workflow for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,14 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -10,14 +17,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -28,6 +32,9 @@ jobs:
           node-version: "22"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm to latest (required for trusted publishing)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -43,6 +50,8 @@ jobs:
           version: pnpm changeset:version
           title: "chore: version packages"
           commit: "chore: version packages"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+


### PR DESCRIPTION
## Summary

Updates the release workflow to properly support npm trusted publishing (OIDC), matching the pattern used in evolution-sdk.

## Changes

- Move `permissions` to workflow level (not job level)
- Add `workflow_dispatch` trigger for manual re-runs
- Add `fetch-depth: 0` to checkout for proper changelog generation
- Add `npm install -g npm@latest` step (required for trusted publishing)
- Add `createGithubReleases: true` for automatic GitHub releases
- Remove `NODE_AUTH_TOKEN` - trusted publishing uses OIDC, no token needed

## Root Cause

The previous workflow was missing proper configuration for npm's trusted publishing, causing the publish step to fail with:
```
E404 Not Found - PUT https://registry.npmjs.org/@no-witness-labs%2fmidday-sdk
Access token expired or revoked. Please try logging in again.
```