### PR TITLE
feat(nix): add compact compiler as derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
               for f in compactc compactc.bin zkir format-compact fixup-compact; do
                 [ -f "$f" ] && cp "$f" $out/bin/
               done
-              chmod +x $out/bin/*
+              find "$out/bin" -type f -exec chmod +x {} +
             '';
 
             meta = {


### PR DESCRIPTION
Replace shell-hook download with proper Nix derivation for Compact compiler.

## Changes

- Compact v0.27.0-rc.1 as hash-verified fetchzip derivation
- Supports x86_64-linux, x86_64-darwin, aarch64-darwin
- Cached in Nix store
- Works with `nix develop --pure`