### PR TITLE
fix(ci): use v* tag filter for X workflow

### DIFF
--- a/.github/workflows/post-release-to-x.yml
+++ b/.github/workflows/post-release-to-x.yml
@@ -9,19 +9,17 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run if: workflow_dispatch (manual) OR workflow_run completed successfully
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Get latest release with changes
         id: release
         run: |
-          # Get the latest @no-witness-labs release with actual changes (not just dependency updates)
-          RELEASES=$(gh api /repos/${{ github.repository }}/releases --jq '[.[] | select(.tag_name | startswith("@no-witness-labs/"))]')
+          # Get the latest release with actual changes (not just dependency updates)
+          RELEASES=$(gh api /repos/${{ github.repository }}/releases --jq '[.[] | select(.tag_name | startswith("v"))]')
 
-          # Variables to track packages
-          FALLBACK_TAG=""
-          FALLBACK_URL=""
-          MIDDAY_TAG=""
-          MIDDAY_URL=""
+          TAG=""
+          URL=""
 
           for i in $(seq 0 10); do
             RELEASE=$(echo $RELEASES | jq ".[$i]")
@@ -37,41 +35,24 @@ jobs:
             # If created in last hour, check if it has real changes (not just dependency updates)
             if [ $AGE -lt 3600 ]; then
               BODY=$(echo $RELEASE | jq -r .body)
-              TAG=$(echo $RELEASE | jq -r .tag_name)
-              URL=$(echo $RELEASE | jq -r .html_url)
+              RELEASE_TAG=$(echo $RELEASE | jq -r .tag_name)
+              RELEASE_URL=$(echo $RELEASE | jq -r .html_url)
 
               # Check for actual changes (not just "Updated dependencies")
               CHANGES_SECTION=$(echo "$BODY" | grep -A 100 "Patch Changes\|Minor Changes\|Major Changes" | tail -n +2)
               REAL_CHANGES=$(echo "$CHANGES_SECTION" | grep -v "Updated dependencies" | grep -v "^[[:space:]]*-[[:space:]]*@" | grep -v "^[[:space:]]*$" | head -1)
 
               if [ -n "$REAL_CHANGES" ]; then
-                # Check if this is the main midday-sdk package
-                if [[ "$TAG" == "@no-witness-labs/midday-sdk@"* ]]; then
-                  if [ -z "$MIDDAY_TAG" ]; then
-                    MIDDAY_TAG=$TAG
-                    MIDDAY_URL=$URL
-                  fi
-                else
-                  # Save as fallback if we haven't found one yet
-                  if [ -z "$FALLBACK_TAG" ]; then
-                    FALLBACK_TAG=$TAG
-                    FALLBACK_URL=$URL
-                  fi
-                fi
+                TAG=$RELEASE_TAG
+                URL=$RELEASE_URL
+                break
               fi
             fi
           done
 
-          # Prioritize midday-sdk package, fall back to other packages
-          if [ -n "$MIDDAY_TAG" ]; then
-            CLEAN_TAG=$(echo $MIDDAY_TAG | sed 's/@//g')
-            echo "tag=$CLEAN_TAG" >> $GITHUB_OUTPUT
-            echo "url=$MIDDAY_URL" >> $GITHUB_OUTPUT
-            echo "found=true" >> $GITHUB_OUTPUT
-          elif [ -n "$FALLBACK_TAG" ]; then
-            CLEAN_TAG=$(echo $FALLBACK_TAG | sed 's/@//g')
-            echo "tag=$CLEAN_TAG" >> $GITHUB_OUTPUT
-            echo "url=$FALLBACK_URL" >> $GITHUB_OUTPUT
+          if [ -n "$TAG" ]; then
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "url=$URL" >> $GITHUB_OUTPUT
             echo "found=true" >> $GITHUB_OUTPUT
           else
             echo "found=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The Post Release to X workflow was looking for releases with tags starting with `@no-witness-labs/` but our releases use `v*` tags (e.g., `v0.2.1`).

This caused the "Tweet new release" step to be skipped because no qualifying releases were found.

## Fix

- Changed tag filter from `startswith("@no-witness-labs/")` to `startswith("v")`
- Simplified the logic (removed multi-package fallback since we have a single package)
- Added condition to support manual `workflow_dispatch` trigger