### PR TITLE
feat(client): add MidnightClientService and layer(config) for Effect DI

### DIFF
--- a/.changeset/eight-owls-pick.md
+++ b/.changeset/eight-owls-pick.md
@@ -1,0 +1,10 @@
+---
+"@no-witness-labs/midday-sdk": patch
+---
+
+Add `MidnightClientService` and `Client.layer(config)` for Effect DI
+
+- Add `MidnightClientService` Context.Tag for pre-initialized client injection
+- Add `Client.layer(config)` to create a Layer with pre-configured client (matches `Cluster.layer(config)` pattern)
+- Add `Client.layerFromWallet(connection, config)` for browser wallet integration
+- Rename `Client.layer()` → `Client.services()` to clarify it provides factory services

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,7 @@ export {
   ContractBuilderLive,
   ContractService,
   ContractLive,
+  MidnightClientService,
 } from './Client.js';
 export type { NetworkConfig } from './Config.js';
 export type { WalletContext, WalletServiceImpl } from './Wallet.js';


### PR DESCRIPTION
## Summary

Adds `MidnightClientService` and `Client.layer(config)` for Effect-style dependency injection of pre-initialized clients.

## Changes

- **`MidnightClientService`** - New Context.Tag that yields a pre-initialized `MidnightClient` instance
- **`Client.layer(config)`** - Creates a Layer providing a configured client (matches `Cluster.layer(config)` pattern)
- **`Client.layerFromWallet(connection, config)`** - Creates a Layer from wallet connection for browser use
- **`Client.services()`** - Renamed from `layer()` to clarify it provides factory services

## Usage

```typescript
import { Effect } from 'effect';
import * as Midday from '@no-witness-labs/midday-sdk';

// Pre-initialized client (recommended for known config at startup)
const clientLayer = Midday.Client.layer({
  seed: 'your-64-char-hex-seed',
  networkConfig: Midday.Config.NETWORKS.local,
  zkConfigProvider: new Midday.HttpZkConfigProvider('http://localhost:3000/zk'),
  privateStateProvider: Midday.inMemoryPrivateStateProvider(),
});

const program = Effect.gen(function* () {
  const client = yield* Midday.MidnightClientService;
  const builder = yield* Midday.Client.effect.contractFrom(client, { module });
  return builder;
});

await Effect.runPromise(program.pipe(Effect.provide(clientLayer)));
```

## Checklist

- [x] Follows `Cluster.layer(config)` pattern for consistency
- [x] Includes changeset
- [x] JSDoc with examples