### PR TITLE
feat: add code snippet images to X release posts

### DIFF
--- a/.github/workflows/post-release-to-x.yml
+++ b/.github/workflows/post-release-to-x.yml
@@ -133,7 +133,7 @@ jobs:
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
 
       - name: Post to X without image
-        if: steps.release.outputs.found == 'true' && steps.extract.outputs.has_code != 'true'
+        if: steps.release.outputs.found == 'true' && steps.extract.outputs.has_code == 'false'
         uses: nearform-actions/github-action-notify-twitter@v1
         with:
           message: |


### PR DESCRIPTION
Extracts code from CHANGELOG and generates a styled image using carbon-now-cli for X posts.