### PR TITLE
docs: add Architecture Decision Records (ADRs)

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -50,6 +50,16 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Architecture',
+          items: [
+            { label: 'Decision Records', slug: 'architecture' },
+            { label: 'ADR-001: Dual API Pattern', slug: 'architecture/adr-001-dual-api-pattern' },
+            { label: 'ADR-002: Module-Function Design', slug: 'architecture/adr-002-module-function-design' },
+            { label: 'ADR-003: Effect Framework', slug: 'architecture/adr-003-effect-framework' },
+            { label: 'ADR-004: Tagged Errors', slug: 'architecture/adr-004-tagged-errors' },
+          ],
+        },
+        {
           label: 'API Reference',
           autogenerate: { directory: 'api' },
         },

--- a/website/src/content/docs/architecture/adr-001-dual-api-pattern.mdx
+++ b/website/src/content/docs/architecture/adr-001-dual-api-pattern.mdx
@@ -1,0 +1,120 @@
+---
+title: "ADR-001: Dual API Pattern"
+description: Why Midday SDK provides Promise, Effect, and Effect DI APIs
+---
+
+## Status
+
+**Accepted**
+
+## Context
+
+Midday SDK targets two distinct developer audiences:
+
+1. **Application developers** who want to quickly build dapps without learning new paradigms
+2. **Advanced developers** who want type-safe error handling, composability, and dependency injection
+
+The underlying Midnight Network libraries are complex and require significant boilerplate. We needed an API design that:
+
+- Lowers the barrier to entry for new developers
+- Provides power features for production applications
+- Avoids forcing developers to learn Effect.ts to use basic features
+- Maintains type safety across all API styles
+
+## Decision
+
+We provide **three complementary API styles** that share the same underlying implementation:
+
+### 1. Promise API (Beginner-Friendly)
+
+Simple async/await interface that feels familiar to JavaScript developers:
+
+```typescript
+const client = await Midday.Client.create(config);
+const builder = await Midday.Client.contractFrom(client, { module });
+const contract = await Midday.ContractBuilder.deploy(builder);
+await Midday.Contract.call(contract, 'increment');
+```
+
+### 2. Effect API (Functional Programming)
+
+For developers who want Effect's benefits without dependency injection:
+
+```typescript
+const program = Effect.gen(function* () {
+  const client = yield* Midday.Client.effect.create(config);
+  const builder = yield* Midday.Client.effect.contractFrom(client, { module });
+  const contract = yield* Midday.ContractBuilder.effect.deploy(builder);
+  return yield* Midday.Contract.effect.call(contract, 'increment');
+});
+
+await Midday.runEffectPromise(program);
+```
+
+### 3. Effect DI (Production Applications)
+
+Full dependency injection for testability and modularity:
+
+```typescript
+const program = Effect.gen(function* () {
+  const clientService = yield* Midday.ClientService;
+  const client = yield* clientService.create(config);
+  // ...
+});
+
+await Effect.runPromise(program.pipe(Effect.provide(Midday.ClientLive)));
+```
+
+### Implementation Strategy
+
+The core logic is written once using Effect.ts:
+
+```typescript
+// Core implementation (Effect-based)
+function createEffect(config: ClientConfig): Effect.Effect<MidnightClient, ClientError> {
+  return Effect.gen(function* () {
+    // ... implementation
+  });
+}
+
+// Promise wrapper
+export async function create(config: ClientConfig): Promise<MidnightClient> {
+  return runEffectWithLogging(createEffect(config), config.logging ?? true);
+}
+
+// Effect API export
+export const effect = {
+  create: createEffect,
+  // ...
+};
+
+// DI Service
+export class ClientService extends Context.Tag('ClientService')<ClientService, ClientServiceImpl>() {}
+export const ClientLive = Layer.succeed(ClientService, { create: createEffect, ... });
+```
+
+## Consequences
+
+### Benefits
+
+- **Low barrier to entry**: Developers can start with Promise API immediately
+- **Gradual adoption**: Teams can migrate to Effect API incrementally
+- **Single source of truth**: All APIs share the same implementation
+- **No runtime overhead**: Promise API adds minimal wrapper cost
+- **Type safety preserved**: All three APIs maintain full TypeScript types
+
+### Tradeoffs
+
+- **API surface area**: Three ways to do the same thing increases documentation needs
+- **Learning curve for Effect**: Advanced features require Effect.ts knowledge
+- **Maintenance burden**: Changes must be reflected in all API styles (mitigated by shared implementation)
+
+### Migration Path
+
+```
+Promise API → Effect API → Effect DI
+    ↑              ↑            ↑
+ Quick start   Composability  Testability
+```
+
+Developers can progressively adopt more powerful patterns as their needs grow.

--- a/website/src/content/docs/architecture/adr-002-module-function-design.mdx
+++ b/website/src/content/docs/architecture/adr-002-module-function-design.mdx
@@ -1,0 +1,138 @@
+---
+title: "ADR-002: Module-Function Design"
+description: Why Midday SDK uses module-functions instead of classes
+---
+
+## Status
+
+**Accepted**
+
+## Context
+
+Traditional SDKs often use class-based OOP patterns:
+
+```typescript
+// Class-based approach (NOT what we do)
+class Client {
+  constructor(config: ClientConfig) { ... }
+  async contractFrom(options: ContractFromOptions): Promise<ContractBuilder> { ... }
+}
+
+const client = new Client(config);
+const builder = await client.contractFrom({ module });
+```
+
+We evaluated this approach against a **module-function pattern** where:
+- Data structures are plain immutable interfaces
+- Operations are standalone functions that take data as the first argument
+- Related functions are grouped into module objects
+
+## Decision
+
+We use the **module-function pattern** throughout the SDK:
+
+### Data as Plain Interfaces
+
+```typescript
+// Plain data - NO methods, NO state
+export interface MidnightClient {
+  readonly wallet: WalletContext | null;
+  readonly networkConfig: NetworkConfig;
+  readonly providers: ContractProviders;
+  readonly logging: boolean;
+}
+
+export interface ContractBuilder {
+  readonly module: LoadedContractModule;
+  readonly providers: ContractProviders;
+  readonly logging: boolean;
+}
+
+export interface ConnectedContract {
+  readonly address: string;
+  readonly instance: unknown;
+  readonly module: LoadedContractModule;
+  readonly providers: ContractProviders;
+  readonly logging: boolean;
+}
+```
+
+### Operations as Module Functions
+
+```typescript
+// Functions grouped by domain
+export async function create(config: ClientConfig): Promise<MidnightClient> { ... }
+export async function contractFrom(client: MidnightClient, options: ContractFromOptions): Promise<ContractBuilder> { ... }
+
+export const ContractBuilder = {
+  deploy: async (builder: ContractBuilder, options?: DeployOptions): Promise<ConnectedContract> => { ... },
+  join: async (builder: ContractBuilder, options: JoinOptions): Promise<ConnectedContract> => { ... },
+  effect: { deploy: deployEffect, join: joinEffect },
+};
+
+export const Contract = {
+  call: async (contract: ConnectedContract, action: string, ...args: unknown[]): Promise<CallResult> => { ... },
+  state: async (contract: ConnectedContract): Promise<unknown> => { ... },
+  ledgerState: async (contract: ConnectedContract): Promise<unknown> => { ... },
+  effect: { call: callEffect, state: stateEffect, ... },
+};
+```
+
+### Usage Pattern
+
+```typescript
+import * as Midday from '@no-witness-labs/midday-sdk';
+
+// Data flows through functions
+const client = await Midday.Client.create(config);
+const builder = await Midday.Client.contractFrom(client, { module });
+const contract = await Midday.ContractBuilder.deploy(builder);
+const result = await Midday.Contract.call(contract, 'increment');
+const state = await Midday.Contract.ledgerState(contract);
+```
+
+## Consequences
+
+### Benefits
+
+1. **Immutability by default**: Plain interfaces can't have hidden mutable state
+2. **Easy testing**: Functions are pure and take all inputs as arguments
+3. **Tree-shaking friendly**: Bundlers can eliminate unused functions
+4. **Explicit data flow**: All state is visible in function signatures
+5. **Composability**: Functions compose better than method chains
+6. **Effect.ts alignment**: Module-functions map naturally to Effect services
+
+### Tradeoffs
+
+1. **Verbosity**: `Midday.Contract.call(contract, 'increment')` vs `contract.call('increment')`
+2. **Discoverability**: IDE autocomplete shows all functions, not just relevant ones
+3. **Familiarity**: OOP developers may find the pattern unfamiliar initially
+
+### Why Not Classes?
+
+| Concern | Classes | Module-Functions |
+|---------|---------|------------------|
+| Hidden state | Easy to introduce | Impossible (no `this`) |
+| Testing | Requires mocking instances | Pure functions, easy to test |
+| Serialization | Complex (methods lost) | Trivial (plain data) |
+| Effect.ts | Awkward fit | Natural alignment |
+| Tree-shaking | Methods not tree-shakeable | Functions are tree-shakeable |
+
+### Pattern Examples
+
+The same pattern is used consistently across the SDK:
+
+```typescript
+// Wallet module
+Wallet.init(seed, networkConfig)
+Wallet.waitForSync(walletContext)
+
+// Providers module
+Providers.create(walletContext, options)
+
+// HttpZkConfigProvider module
+HttpZkConfigProvider.make(baseUrl)
+HttpZkConfigProvider.getZKIR(provider, circuitId)
+```
+
+This consistency makes the SDK predictable and easy to learn.

--- a/website/src/content/docs/architecture/adr-003-effect-framework.mdx
+++ b/website/src/content/docs/architecture/adr-003-effect-framework.mdx
@@ -1,0 +1,177 @@
+---
+title: "ADR-003: Effect as Core Runtime"
+description: Why Midday SDK uses Effect.ts as its foundation
+---
+
+## Status
+
+**Accepted**
+
+## Context
+
+Building a blockchain SDK involves complex challenges:
+
+- **Async operations**: Wallet sync, network calls, proof generation
+- **Error handling**: Many failure modes (network, wallet, contract, ZK proofs)
+- **Resource management**: Connections, caches, providers
+- **Composability**: Operations need to be combined in various ways
+- **Dependency injection**: For testing and modularity
+
+We evaluated several approaches:
+
+1. **Raw Promises**: Simple but error handling is implicit, no DI
+2. **fp-ts**: Good types but verbose, smaller ecosystem
+3. **Effect.ts**: Comprehensive, typed errors, DI, growing ecosystem
+
+## Decision
+
+We use **Effect.ts** as the core runtime for all SDK operations.
+
+### Core Effect Patterns
+
+#### Effect.gen for Sequential Composition
+
+```typescript
+function createEffect(config: ClientConfig): Effect.Effect<MidnightClient, ClientError> {
+  return Effect.gen(function* () {
+    yield* Effect.logDebug('Initializing wallet...');
+
+    const walletContext = yield* Wallet.effect.init(walletSeed, networkConfig).pipe(
+      Effect.mapError((e) => new ClientError({
+        cause: e,
+        message: `Failed to initialize wallet: ${e.message}`,
+      })),
+    );
+
+    yield* Wallet.effect.waitForSync(walletContext).pipe(
+      Effect.mapError((e) => new ClientError({
+        cause: e,
+        message: `Failed to sync wallet: ${e.message}`,
+      })),
+    );
+
+    yield* Effect.logDebug('Wallet synced');
+
+    const providers = Providers.create(walletContext, providerOptions);
+
+    return { wallet: walletContext, networkConfig, providers, logging };
+  });
+}
+```
+
+#### Effect.tryPromise for External Calls
+
+```typescript
+const txData = yield* Effect.tryPromise({
+  try: () => callTx[action](...args),
+  catch: (cause) => new ContractError({
+    cause,
+    message: `Failed to call ${action}: ${cause instanceof Error ? cause.message : String(cause)}`,
+  }),
+});
+```
+
+#### Context.Tag for Dependency Injection
+
+```typescript
+export class ClientService extends Context.Tag('ClientService')<
+  ClientService,
+  ClientServiceImpl
+>() {}
+
+export const ClientLive: Layer.Layer<ClientService> = Layer.succeed(ClientService, {
+  create: createEffect,
+  fromWallet: fromWalletEffect,
+  contractFrom: contractFromEffect,
+  waitForTx: waitForTxEffect,
+});
+```
+
+#### Layer for Pre-configured Dependencies
+
+```typescript
+export function layer(config: ClientConfig): Layer.Layer<MidnightClientService, ClientError> {
+  return Layer.effect(MidnightClientService, createEffect(config));
+}
+
+// Usage
+const clientLayer = Midday.Client.layer(config);
+const program = Effect.gen(function* () {
+  const client = yield* Midday.MidnightClientService;
+  // client is automatically available
+});
+await Effect.runPromise(program.pipe(Effect.provide(clientLayer)));
+```
+
+### Effect Runtime Utilities
+
+We provide utilities that clean up Effect internals from stack traces:
+
+```typescript
+// src/utils/effect-runtime.ts
+export async function runEffectPromise<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isFailure(exit)) {
+    const error = Cause.squash(exit.cause);
+    const cleanedError = cleanErrorChain(error); // Removes Effect internals
+    throw cleanedError;
+  }
+  return exit.value;
+}
+
+export async function runEffectWithLogging<A, E>(
+  effect: Effect.Effect<A, E>,
+  logging: boolean,
+): Promise<A> {
+  const loggerLayer = logging
+    ? Layer.merge(Logger.pretty, Logger.minimumLogLevel(LogLevel.Debug))
+    : Logger.pretty;
+  return runEffectPromise(Effect.provide(effect, loggerLayer));
+}
+```
+
+## Consequences
+
+### Benefits
+
+1. **Typed errors**: Error types are in the signature `Effect<A, E>`, not hidden
+2. **Composability**: Effects compose with `pipe`, `map`, `flatMap`, `gen`
+3. **Built-in logging**: `Effect.logDebug`, `Effect.logInfo`, etc.
+4. **Resource safety**: `Effect.acquireRelease` for cleanup
+5. **Concurrency**: `Effect.all`, `Effect.race`, `Effect.forEach` with concurrency control
+6. **Dependency injection**: Context.Tag and Layer for testability
+7. **Interruption**: Effects can be cancelled cleanly
+
+### Tradeoffs
+
+1. **Learning curve**: Effect.ts has concepts to learn (Effect, Layer, Context)
+2. **Bundle size**: Effect.ts adds to the bundle (~50KB gzipped)
+3. **Stack traces**: Effect adds frames (mitigated by our cleanup utilities)
+4. **Debugging**: Requires understanding Effect execution model
+
+### Why Not Just Promises?
+
+| Feature | Promises | Effect.ts |
+|---------|----------|-----------|
+| Error types | `Promise<T>` (errors untyped) | `Effect<T, E>` (errors typed) |
+| Composition | `.then()` chains | `pipe`, `gen`, `map`, `flatMap` |
+| Logging | Manual | Built-in `Effect.log*` |
+| DI | None | Context.Tag + Layer |
+| Cancellation | Complex | Built-in interruption |
+| Resource cleanup | try/finally | `acquireRelease` |
+
+### Integration with Promise API
+
+Effect is an implementation detail for Promise API users:
+
+```typescript
+// User writes:
+const client = await Midday.Client.create(config);
+
+// Under the hood:
+export async function create(config: ClientConfig): Promise<MidnightClient> {
+  return runEffectWithLogging(createEffect(config), config.logging ?? true);
+}
+```
+
+Promise API users never see Effect types unless they choose the Effect API.

--- a/website/src/content/docs/architecture/adr-004-tagged-errors.mdx
+++ b/website/src/content/docs/architecture/adr-004-tagged-errors.mdx
@@ -1,0 +1,215 @@
+---
+title: "ADR-004: Tagged Error Handling"
+description: Why Midday SDK uses Effect's Data.TaggedError pattern
+---
+
+## Status
+
+**Accepted**
+
+## Context
+
+Error handling in JavaScript/TypeScript has several challenges:
+
+1. **Untyped errors**: `throw` accepts anything, `catch` gets `unknown`
+2. **Lost context**: Stack traces often don't include business context
+3. **Error classification**: Hard to distinguish error types programmatically
+4. **Error composition**: Combining errors from different operations is awkward
+
+We needed an error handling strategy that:
+
+- Provides typed, discriminated errors
+- Preserves original error context
+- Enables pattern matching on error types
+- Works well with Effect.ts
+
+## Decision
+
+We use **Effect's `Data.TaggedError`** pattern for all SDK errors.
+
+### Error Definition Pattern
+
+```typescript
+// src/Client.ts
+export class ClientError extends Data.TaggedError('ClientError')<{
+  readonly cause: unknown;
+  readonly message: string;
+}> {}
+
+export class ContractError extends Data.TaggedError('ContractError')<{
+  readonly cause: unknown;
+  readonly message: string;
+}> {}
+```
+
+```typescript
+// src/providers/errors.ts
+export class ProviderError extends Data.TaggedError('ProviderError')<{
+  readonly cause: unknown;
+  readonly message: string;
+}> {}
+
+export class ZkConfigError extends Data.TaggedError('ZkConfigError')<{
+  readonly cause: unknown;
+  readonly message: string;
+}> {}
+
+export class PrivateStateError extends Data.TaggedError('PrivateStateError')<{
+  readonly cause: unknown;
+  readonly message: string;
+}> {}
+```
+
+```typescript
+// src/wallet/errors.ts
+export class WalletError extends Data.TaggedError('WalletError')<{
+  readonly cause: unknown;
+  readonly message: string;
+}> {}
+```
+
+### Error Hierarchy
+
+```
+SDK Errors
+├── ClientError        # Client creation/configuration failures
+├── ContractError      # Contract deployment/call failures
+├── WalletError        # Wallet initialization/sync failures
+├── ProviderError      # Provider setup failures
+├── ZkConfigError      # ZK configuration loading failures
+└── PrivateStateError  # Private state storage failures
+```
+
+### Error Creation
+
+Errors wrap the original cause and add a human-readable message:
+
+```typescript
+function contractFromEffect(
+  client: MidnightClient,
+  options: ContractFromOptions,
+): Effect.Effect<ContractBuilder, ClientError> {
+  return Effect.try({
+    try: () => { /* ... */ },
+    catch: (cause) =>
+      new ClientError({
+        cause,
+        message: `Failed to load contract: ${cause instanceof Error ? cause.message : String(cause)}`,
+      }),
+  });
+}
+```
+
+### Error Handling with Effect
+
+#### Catch Specific Error Types
+
+```typescript
+const program = Midday.Contract.effect.call(contract, 'increment').pipe(
+  Effect.catchTag('ContractError', (error) => {
+    console.error('Contract call failed:', error.message);
+    return Effect.succeed({ status: 'failed' });
+  })
+);
+```
+
+#### Catch All Errors
+
+```typescript
+const program = Midday.Client.effect.create(config).pipe(
+  Effect.catchAll((error) => {
+    // error is typed as ClientError
+    console.error('Client creation failed:', error.message);
+    return Effect.fail(error);
+  })
+);
+```
+
+#### Transform Errors
+
+```typescript
+const walletContext = yield* Wallet.effect.init(seed, networkConfig).pipe(
+  Effect.mapError((e) => new ClientError({
+    cause: e,
+    message: `Failed to initialize wallet: ${e.message}`,
+  })),
+);
+```
+
+### Error Properties
+
+All errors have consistent properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `_tag` | `string` | Discriminator for pattern matching |
+| `cause` | `unknown` | Original error or value |
+| `message` | `string` | Human-readable description |
+
+### Clean Stack Traces
+
+We clean Effect internals from stack traces for better debugging:
+
+```typescript
+// src/utils/effect-runtime.ts
+function cleanErrorChain(error: Error): Error {
+  // Remove Effect.ts internal frames
+  // Preserve original error chain
+  // Return clean error for Promise API users
+}
+```
+
+## Consequences
+
+### Benefits
+
+1. **Type safety**: Errors are part of the type signature
+2. **Pattern matching**: `catchTag` enables precise error handling
+3. **Context preservation**: Original cause is always available
+4. **Consistent structure**: All errors have `_tag`, `cause`, `message`
+5. **Composability**: Errors can be mapped and transformed
+
+### Tradeoffs
+
+1. **Verbosity**: Creating tagged errors requires more code than `throw new Error()`
+2. **Learning curve**: Developers must understand tagged unions
+3. **Effect dependency**: TaggedError is an Effect.ts concept
+
+### Error Handling Examples
+
+#### Promise API (Errors as Exceptions)
+
+```typescript
+try {
+  const client = await Midday.Client.create(config);
+} catch (error) {
+  if (error instanceof Midday.ClientError) {
+    console.error('Client error:', error.message);
+    console.error('Cause:', error.cause);
+  }
+}
+```
+
+#### Effect API (Typed Errors)
+
+```typescript
+const program = Effect.gen(function* () {
+  const client = yield* Midday.Client.effect.create(config);
+  return client;
+}).pipe(
+  Effect.catchTag('ClientError', (error) => {
+    // error is typed as ClientError
+    Effect.logError(`Failed: ${error.message}`);
+    return Effect.fail(error);
+  })
+);
+```
+
+### Why Not Plain Error Classes?
+
+| Feature | Plain Error | Data.TaggedError |
+|---------|-------------|------------------|
+| Type discrimination | `instanceof` (runtime) | `_tag` (compile-time) |
+| Effect integration | Manual | Built-in `catchTag` |
+| Exhaustiveness | No compiler help | Compiler checks all tags |
+| Immutability | Mutable | Immutable by default |

--- a/website/src/content/docs/architecture/index.mdx
+++ b/website/src/content/docs/architecture/index.mdx
@@ -1,0 +1,52 @@
+---
+title: Architecture Decision Records
+description: Documentation of key architectural decisions in Midday SDK
+---
+
+Architecture Decision Records (ADRs) document the key design choices made during the development of Midday SDK. These records explain the context, decision, and consequences of each architectural choice.
+
+## What are ADRs?
+
+ADRs are short documents that capture important architectural decisions along with their context and consequences. They help:
+
+- **New contributors** understand why the codebase is structured the way it is
+- **Maintainers** remember the reasoning behind past decisions
+- **Users** understand the design philosophy of the SDK
+
+## Decision Records
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](/midday-sdk/architecture/adr-001-dual-api-pattern/) | Dual API Pattern (Promise + Effect) | Accepted |
+| [ADR-002](/midday-sdk/architecture/adr-002-module-function-design/) | Module-Function Design | Accepted |
+| [ADR-003](/midday-sdk/architecture/adr-003-effect-framework/) | Effect as Core Runtime | Accepted |
+| [ADR-004](/midday-sdk/architecture/adr-004-tagged-errors/) | Tagged Error Handling | Accepted |
+
+## ADR Template
+
+When proposing a new ADR, use the following structure:
+
+```markdown
+# ADR-XXX: Title
+
+## Status
+Proposed | Accepted | Deprecated | Superseded
+
+## Context
+What is the issue that we're seeing that motivates this decision?
+
+## Decision
+What is the change that we're proposing and/or doing?
+
+## Consequences
+What becomes easier or harder as a result of this decision?
+```
+
+## Contributing
+
+To propose a new architectural decision:
+
+1. Create a new ADR file following the template
+2. Submit a pull request with the proposed decision
+3. Discuss in the PR until consensus is reached
+4. Update status to "Accepted" when merged


### PR DESCRIPTION
- ADR-001: Dual API Pattern (Promise + Effect + Effect DI)
- ADR-002: Module-Function Design (vs class-based)
- ADR-003: Effect Framework as Core Runtime
- ADR-004: Tagged Error Handling Strategy

Includes ADR template and index page for future ADRs.

Closes #34