### PR TITLE
Fix: Exclude external package APIs from docs

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
           typeDoc: {
             excludePrivate: true,
             excludeInternal: true,
+            excludeExternals: true,
             readme: 'none',
           },
         }),


### PR DESCRIPTION
Adds excludeExternals flag to TypeDoc config to prevent Effect and other dependency APIs from appearing in SDK documentation.