### PR TITLE
feat: add generic type inference for type-safe contracts

### DIFF
--- a/.changeset/young-swans-stare.md
+++ b/.changeset/young-swans-stare.md
@@ -1,0 +1,27 @@
+---
+"@no-witness-labs/midday-sdk": patch
+---
+
+Add type-safe contract inference
+
+Contract types are now automatically inferred from your Compact module:
+
+```typescript
+import * as CounterContract from './contracts/counter/contract';
+
+const contract = await client.loadContract({
+  module: CounterContract,
+  zkConfig: Midday.ZkConfig.fromPath('./contracts/counter'),
+});
+
+// ledgerState() returns typed Ledger - no cast needed
+const state = await contract.ledgerState();
+console.log(state.counter); // bigint
+
+// call() autocompletes circuit names
+await contract.call('increment'); // 'increment' | 'decrement'
+```
+
+New type utilities:
+- `InferLedger<M>` - extract ledger type from module
+- `InferCircuits<M>` - extract circuit names as union type

--- a/test/e2e/contract.e2e.test.ts
+++ b/test/e2e/contract.e2e.test.ts
@@ -3,8 +3,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { Cluster } from '../../src/devnet/index.js';
 import * as Midday from '../../src/index.js';
-import * as CounterContract from '../../contracts/counter/index.js';
-import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+import * as CounterContract from '../../contracts/counter/contract/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -75,12 +74,9 @@ describe('Contract E2E Tests', () => {
     });
 
     it('should deploy counter contract', { timeout: 180_000 }, async () => {
-      // Load contract with zkConfig (per-contract)
-      const zkConfig = new NodeZkConfigProvider(COUNTER_CONTRACT_DIR);
-
       contract = await client.loadContract({
-        module: CounterContract as Midday.Client.ContractModule,
-        zkConfig,
+        module: CounterContract,
+        zkConfig: Midday.ZkConfig.fromPath(COUNTER_CONTRACT_DIR),
         privateStateId: 'counter-e2e-test',
       });
 
@@ -133,12 +129,9 @@ describe('Contract E2E Tests', () => {
         logging: true,
       });
 
-      // Load contract with zkConfig (per-contract)
-      const zkConfig = new NodeZkConfigProvider(COUNTER_CONTRACT_DIR);
-
       const joinedContract = await client2.loadContract({
-        module: CounterContract as Midday.Client.ContractModule,
-        zkConfig,
+        module: CounterContract,
+        zkConfig: Midday.ZkConfig.fromPath(COUNTER_CONTRACT_DIR),
         privateStateId: 'counter-e2e-test-client2',
       });
 


### PR DESCRIPTION
Contract types are now automatically inferred from your Compact module:

\`\`\`typescript
import * as CounterContract from './contracts/counter/contract';

const contract = await client.loadContract({
  module: CounterContract,
  zkConfig: Midday.ZkConfig.fromPath('./contracts/counter'),
});

// ledgerState() returns typed Ledger - no cast needed
const state = await contract.ledgerState();
console.log(state.counter); // bigint

// call() autocompletes circuit names
await contract.call('increment'); // 'increment' | 'decrement'
\`\`\`

## Changes

- Add \`ContractModule<TLedger, TCircuits>\` interface with generic parameters
- Add \`InferLedger<M>\` and \`InferCircuits<M>\` type utilities
- Make \`LoadContractOptions<M>\` generic for type inference
- Add generics to \`Contract<TLedger, TCircuits>\` interface
- \`ledgerState()\` returns \`Promise<TLedger>\` instead of \`unknown\`
- \`call()\` requires \`TCircuits\` for action parameter

Closes #39