### PR TITLE
feat(devnet): auto-build faucet/fee-relay Docker images in SDK

### DIFF
--- a/.changeset/auto-build-docker-images.md
+++ b/.changeset/auto-build-docker-images.md
@@ -1,0 +1,10 @@
+---
+"@no-witness-labs/midday-sdk": patch
+---
+
+Auto-build faucet/fee-relay Docker images inside SDK
+
+- Add `Images.build()` for building Docker images from local context
+- Auto-build in `Faucet.startDocker()` and `FeeRelay.startDocker()` when image is missing
+- Ship `docker/` build contexts in npm package
+- Remove `ensureDockerImage()` boilerplate from examples and template

--- a/examples/devnet-testing/src/index.ts
+++ b/examples/devnet-testing/src/index.ts
@@ -9,31 +9,9 @@
  * Prerequisites:
  * - Docker installed and running
  * - Sufficient system resources for Midnight containers
- * - For Docker faucet: build image first with `cd docker/faucet && ./build.sh`
  */
 import { Cluster, Faucet, FeeRelay } from '@no-witness-labs/midday-sdk/devnet';
 import * as Midday from '@no-witness-labs/midday-sdk';
-
-// Build a Docker image if needed
-async function ensureDockerImage(reference: string, dockerDir: string, label: string): Promise<void> {
-  const Docker = (await import('dockerode')).default;
-  const docker = new Docker();
-  const images = await docker.listImages({ filters: { reference: [reference] } });
-
-  if (images.length > 0) {
-    return;
-  }
-
-  // Build the image (multi-stage build does everything inside Docker)
-  console.log(`   Building ${label} Docker image (first time only)...`);
-  const { execSync } = await import('child_process');
-  const path = await import('path');
-  const dir = path.resolve(import.meta.dirname, dockerDir);
-
-  execSync(`docker build -t ${reference} .`, { cwd: dir, stdio: 'pipe' });
-
-  console.log(`   ${label} image built successfully`);
-}
 
 async function main() {
   console.log('=== Devnet Testing Example ===\n');
@@ -70,8 +48,6 @@ async function main() {
 
     // Step 4: Start faucet and fee relay for browser apps
     console.log('\n4. Starting faucet and fee relay...');
-    await ensureDockerImage('midday-faucet:latest', '../../../docker/faucet', 'faucet');
-    await ensureDockerImage('midday-fee-relay:latest', '../../../docker/fee-relay', 'fee relay');
     await Faucet.startDocker(cluster.networkConfig);
     console.log('   Faucet: http://localhost:3001/faucet');
     await FeeRelay.startDocker(cluster.networkConfig);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "dist",
+    "docker",
     "README.md"
   ],
   "scripts": {

--- a/src/devnet/Faucet.ts
+++ b/src/devnet/Faucet.ts
@@ -32,6 +32,7 @@ import {
 import type { NetworkConfig } from '../Config.js';
 import { hexToBytes } from '../utils/hex.js';
 import { FaucetError } from './errors.js';
+import * as Images from './Images.js';
 
 /**
  * Genesis wallet seed that is pre-funded in local devnet.
@@ -373,6 +374,15 @@ export async function startDocker(
     image = 'midday-faucet:latest',
     clusterName = 'midday-devnet',
   } = options;
+
+  // Auto-build image if not available
+  const available = await Images.isAvailable(image);
+  if (!available) {
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const sdkRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+    Images.build(image, resolve(sdkRoot, 'docker/faucet'));
+  }
 
   const Docker = (await import('dockerode')).default;
   const docker = new Docker();

--- a/src/devnet/FeeRelay.ts
+++ b/src/devnet/FeeRelay.ts
@@ -26,6 +26,7 @@ import type { UnboundTransaction } from '@midnight-ntwrk/midnight-js-types';
 
 import type { NetworkConfig } from '../Config.js';
 import { hexToBytes, bytesToHex } from '../utils/hex.js';
+import * as Images from './Images.js';
 
 /**
  * Genesis wallet seed that is pre-funded in local devnet.
@@ -334,6 +335,15 @@ export async function startDocker(
     image = 'midday-fee-relay:latest',
     clusterName = 'midday-devnet',
   } = options;
+
+  // Auto-build image if not available
+  const available = await Images.isAvailable(image);
+  if (!available) {
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const sdkRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+    Images.build(image, resolve(sdkRoot, 'docker/fee-relay'));
+  }
 
   const Docker = (await import('dockerode')).default;
   const docker = new Docker();

--- a/src/devnet/Images.ts
+++ b/src/devnet/Images.ts
@@ -6,6 +6,7 @@
  */
 
 import Docker from 'dockerode';
+import { execSync } from 'child_process';
 
 /**
  * Error thrown when image operations fail.
@@ -93,6 +94,18 @@ export async function pull(imageName: string): Promise<void> {
   });
 
   console.log(`[Devnet] ✓ Image ready: ${imageName}`);
+}
+
+/**
+ * Build a Docker image from a local directory.
+ *
+ * @since 0.3.0
+ * @category management
+ */
+export function build(imageName: string, contextPath: string): void {
+  console.log(`[Devnet] Building ${imageName} Docker image (first time only)...`);
+  execSync(`docker build -t ${imageName} .`, { cwd: contextPath, stdio: 'pipe' });
+  console.log(`[Devnet] ✓ Image built: ${imageName}`);
 }
 
 /**


### PR DESCRIPTION
Move Docker image building into startDocker() so consumers no longer need to ship docker directories or ensureDockerImage() boilerplate.