### PR TITLE
refactor: simplify Client module, extract FeeRelay, add typed contract helpers

### DIFF
--- a/.changeset/improve-api-module.md
+++ b/.changeset/improve-api-module.md
@@ -1,0 +1,30 @@
+---
+"@no-witness-labs/midday-sdk": minor
+---
+
+Simplify Client module and improve API ergonomics
+
+### Breaking Changes
+
+- Removed deprecated exports: `ClientService`, `ClientServiceImpl`, `ClientLive`, `services()`, `ClientData`, `ContractState`, `Contract` (legacy union type), `ContractData`, `createContractHandle`
+- Removed deprecated Promise wrappers from Wallet: `init()`, `waitForSync()`, `close()`, `providers()`, `connectWallet()`, `disconnectWallet()`
+- Removed `wallet` and `relayerWallet` properties from `MiddayClient` handle
+- `layerFromWallet` no longer accepts `zkConfigProvider` in its config
+
+### New Features
+
+- **`FeeRelay` module** — centralised fee relay logic (seed-based and HTTP-based) extracted from Client
+- **`DeployedContractFor<M>`** — convenience type alias for fully-typed deployed contracts
+- **`LoadedContractFor<M>`** — convenience type alias for fully-typed loaded contracts
+- **`FromWalletConfig`** — dedicated config interface for `Client.fromWallet()`
+- **`effect.fromWalletScoped`** — scoped variant for browser wallet connections
+- **Configurable `txTtlMs`** — transaction TTL now configurable via `ClientConfig`, `FromWalletConfig`, and fee relay options (default: 30 minutes via `Config.DEFAULT_TX_TTL_MS`)
+
+### Improvements
+
+- Client internals simplified: removed `ClientData` indirection, `closeClientEffect`, and duplicated provider assembly logic
+- Scoped variants (`createScoped`, `fromWalletScoped`) now reuse the Effect path via `acquireRelease` instead of duplicating logic
+- `Effect.orDie` replaces `Effect.ignore`/`Effect.catchAll` in acquireRelease release functions — close failures are now visible defects
+- `layerFromWallet` reuses `effect.fromWalletScoped` instead of duplicating the pipeline
+- All internal module imports follow Effect-style `import * as Module` pattern with qualified type access
+- All tests and JSDoc examples updated to use typed `contract.actions.*()` instead of untyped `contract.call()`

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -11,7 +11,7 @@
  * const client = await Midday.Client.create(config);
  * const contract = await client.loadContract({ path: './contracts/counter' });
  * await contract.deploy();
- * await contract.call('increment');
+ * await contract.actions.increment();
  *
  * // Effect user — compositional
  * const program = Effect.gen(function* () {
@@ -27,37 +27,18 @@
  */
 
 import { Context, Data, Duration, Effect, Layer, Scope } from 'effect';
-import { Transaction } from '@midnight-ntwrk/ledger-v7';
 import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
-import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
 import type {
   WalletProvider,
   MidnightProvider,
-  ZKConfigProvider,
   PrivateStateProvider,
 } from '@midnight-ntwrk/midnight-js-types';
 
 import * as Config from './Config.js';
+import * as Contract from './Contract.js';
+import * as FeeRelay from './FeeRelay.js';
+import * as Runtime from './Runtime.js';
 import * as Wallet from './Wallet.js';
-import type { NetworkConfig } from './Config.js';
-import type { WalletContext } from './Wallet.js';
-import type { WalletConnection, WalletProviders, ConnectedWallet } from './Wallet.js';
-import type {
-  LoadedContract,
-  ContractModule,
-  InferLedger,
-  InferCircuits,
-  InferActions,
-  LoadContractOptions,
-  LoadedContractData,
-  FinalizedTxData,
-  PublicDataProvider,
-  LedgerParser,
-  ReadonlyContract,
-} from './Contract.js';
-import { loadContractModuleEffect, createLoadedContractHandle, createReadonlyContractHandle } from './Contract.js';
-import { runEffectWithLogging } from './Runtime.js';
-import { bytesToHex, hexToBytes } from './Utils.js';
 
 // =============================================================================
 // Errors
@@ -126,10 +107,10 @@ export interface StorageConfig {
 export interface BaseProviders {
   walletProvider: WalletProvider;
   midnightProvider: MidnightProvider;
-  publicDataProvider: ReturnType<typeof indexerPublicDataProvider>;
+  publicDataProvider: Contract.PublicDataProvider;
   privateStateProvider: PrivateStateProvider;
   /** Network configuration for creating per-contract proof providers */
-  networkConfig: NetworkConfig;
+  networkConfig: Config.NetworkConfig;
 }
 
 /**
@@ -140,13 +121,15 @@ export interface BaseProviders {
  */
 export interface CreateBaseProvidersOptions {
   /** Network configuration */
-  networkConfig: NetworkConfig;
+  networkConfig: Config.NetworkConfig;
   /** Private state provider */
   privateStateProvider: PrivateStateProvider;
   /** Storage configuration */
   storageConfig?: StorageConfig;
   /** Optional fee relay wallet — uses this wallet for balanceTx/submitTx while keeping the primary wallet for ZK proofs */
-  feeRelayWallet?: WalletContext;
+  feeRelayWallet?: Wallet.WalletContext;
+  /** Transaction TTL in milliseconds (default: 30 minutes) */
+  txTtlMs?: number;
 }
 
 // =============================================================================
@@ -156,6 +139,10 @@ export interface CreateBaseProvidersOptions {
 /**
  * Configuration for creating a client.
  *
+ * **Constraint:** Only one network ID is supported per process. The Midnight SDK
+ * uses a global `setNetworkId` call internally, so creating two clients targeting
+ * different networks in the same process will cause undefined behaviour.
+ *
  * @since 0.2.0
  * @category model
  */
@@ -163,9 +150,9 @@ export interface ClientConfig {
   /** Network to connect to (default: 'local') */
   network?: string;
   /** Custom network configuration (overrides network preset) */
-  networkConfig?: NetworkConfig;
+  networkConfig?: Config.NetworkConfig;
   /** Pre-created wallet (from Wallet.fromSeed or Wallet.fromBrowser) */
-  wallet?: ConnectedWallet;
+  wallet?: Wallet.ConnectedWallet;
   /** Wallet seed (required for non-local networks). Ignored if `wallet` is provided. */
   seed?: string;
   /** Private state provider (required) */
@@ -175,10 +162,20 @@ export interface ClientConfig {
   /** Enable logging (default: true) */
   logging?: boolean;
   /** Fee relay — delegate fee payment to a funded wallet so non-funded wallets can transact.
-   * - `{ seed }` — Node.js: initialize a local wallet from seed
-   * - `{ url }` — Browser: proxy to a fee relay HTTP server
+   *
+   * Which variant is valid depends on the wallet mode:
+   * - **`{ seed }`** — Node.js only. Initialises a local relay wallet from seed.
+   *   Valid with seed-based init (`Client.create({ seed })`).
+   *   **Not valid** with a pre-created `wallet` (ConnectedWallet).
+   * - **`{ url }`** — Browser or Node.js. Proxies `balanceTx`/`submitTx` to a remote HTTP fee relay server.
+   *   Valid with a pre-created `wallet` (ConnectedWallet).
+   *   **Not valid** with seed-based init (`Client.create({ seed })`).
+   *
+   * Both variants are accepted by `Client.fromWallet()`.
    */
   feeRelay?: { seed: string } | { url: string };
+  /** Transaction TTL in milliseconds (default: 30 minutes). Used as the fallback when no per-call TTL is provided to `balanceTx`. */
+  txTtlMs?: number;
 }
 
 /**
@@ -193,7 +190,7 @@ export interface ReadonlyClientConfig {
   /** Network to connect to (default: 'local') */
   network?: string;
   /** Custom network configuration (overrides network preset) */
-  networkConfig?: NetworkConfig;
+  networkConfig?: Config.NetworkConfig;
   /** Enable logging (default: false) */
   logging?: boolean;
 }
@@ -203,16 +200,20 @@ export interface ReadonlyClientConfig {
 // =============================================================================
 
 /**
- * Internal client data (plain object).
- * @internal
+ * Configuration for creating a client from a wallet connection.
+ *
+ * @since 0.11.0
+ * @category model
  */
-interface ClientData {
-  readonly wallet: WalletContext | null;
-  readonly connectedWallet: ConnectedWallet | null;
-  readonly relayerWallet: WalletContext | null;
-  readonly networkConfig: NetworkConfig;
-  readonly providers: BaseProviders;
-  readonly logging: boolean;
+export interface FromWalletConfig {
+  /** Private state provider (required) */
+  privateStateProvider: PrivateStateProvider;
+  /** Enable logging (default: true) */
+  logging?: boolean;
+  /** Fee relay config. Both `{ seed }` and `{ url }` are valid for `fromWallet`. */
+  feeRelay?: { seed: string } | { url: string };
+  /** Transaction TTL in milliseconds (default: 30 minutes). */
+  txTtlMs?: number;
 }
 
 // =============================================================================
@@ -231,9 +232,9 @@ interface ClientData {
  */
 export interface ReadonlyClient {
   /** Network configuration */
-  readonly networkConfig: NetworkConfig;
+  readonly networkConfig: Config.NetworkConfig;
   /** Public data provider (for advanced use) */
-  readonly provider: PublicDataProvider;
+  readonly provider: Contract.PublicDataProvider;
 
   /**
    * Load a contract module for read-only state queries.
@@ -252,9 +253,9 @@ export interface ReadonlyClient {
    * console.log(state.counter); // 42n
    * ```
    */
-  loadContract<M extends ContractModule>(
+  loadContract<M extends Contract.ContractModule>(
     options: { module: M },
-  ): ReadonlyContract<InferLedger<M>>;
+  ): Contract.ReadonlyContract<Contract.InferLedger<M>>;
 }
 
 /**
@@ -265,13 +266,9 @@ export interface ReadonlyClient {
  */
 export interface MiddayClient {
   /** Network configuration */
-  readonly networkConfig: NetworkConfig;
+  readonly networkConfig: Config.NetworkConfig;
   /** Base providers (for advanced use — no zkConfig) */
   readonly providers: BaseProviders;
-  /** Raw wallet context (null if using wallet connector) */
-  readonly wallet: WalletContext | null;
-  /** Fee relay wallet context (null if fee relay not configured) */
-  readonly relayerWallet: WalletContext | null;
 
   /**
    * Load a contract module. Returns a `LoadedContract` —
@@ -279,9 +276,9 @@ export interface MiddayClient {
    *
    * @typeParam M - Contract module type (inferred from options.module)
    */
-  loadContract<M extends ContractModule>(
-    options: LoadContractOptions<M>,
-  ): Promise<LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>>;
+  loadContract<M extends Contract.ContractModule>(
+    options: Contract.LoadContractOptions<M>,
+  ): Promise<Contract.LoadedContract<Contract.InferLedger<M>, Contract.InferCircuits<M>, Contract.InferActions<M>>>;
 
   /** Wait for a transaction to be finalized.
    *
@@ -289,7 +286,7 @@ export interface MiddayClient {
    * @param options - Optional settings (e.g., timeout)
    * @throws {TxTimeoutError} When the timeout is exceeded
    */
-  waitForTx(txHash: string, options?: WaitForTxOptions): Promise<FinalizedTxData>;
+  waitForTx(txHash: string, options?: WaitForTxOptions): Promise<Contract.FinalizedTxData>;
 
   /**
    * Close the client and release all resources.
@@ -307,10 +304,10 @@ export interface MiddayClient {
 
   /** Effect versions of client methods */
   readonly effect: {
-    loadContract<M extends ContractModule>(
-      options: LoadContractOptions<M>,
-    ): Effect.Effect<LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>, ClientError>;
-    waitForTx(txHash: string, options?: WaitForTxOptions): Effect.Effect<FinalizedTxData, ClientError | TxTimeoutError>;
+    loadContract<M extends Contract.ContractModule>(
+      options: Contract.LoadContractOptions<M>,
+    ): Effect.Effect<Contract.LoadedContract<Contract.InferLedger<M>, Contract.InferCircuits<M>, Contract.InferActions<M>>, ClientError>;
+    waitForTx(txHash: string, options?: WaitForTxOptions): Effect.Effect<Contract.FinalizedTxData, ClientError | TxTimeoutError>;
     close(): Effect.Effect<void, ClientError>;
   };
 }
@@ -324,12 +321,12 @@ export interface MiddayClient {
 // =============================================================================
 
 function createBaseProvidersEffect(
-  walletContext: WalletContext,
+  walletContext: Wallet.WalletContext,
   options: CreateBaseProvidersOptions,
 ): Effect.Effect<BaseProviders, ClientError> {
-  return Wallet.effect.providers(walletContext).pipe(
+  return Wallet.effect.providers(walletContext, { txTtlMs: options.txTtlMs }).pipe(
     Effect.map(({ walletProvider, midnightProvider }) => {
-      const { networkConfig, privateStateProvider, feeRelayWallet } = options;
+      const { networkConfig, privateStateProvider, feeRelayWallet, txTtlMs } = options;
 
       setNetworkId(networkConfig.networkId as 'undeployed');
 
@@ -338,27 +335,9 @@ function createBaseProvidersEffect(
 
       const publicDataProvider = Config.publicDataProvider(networkConfig);
 
-      const effectiveWalletProvider: WalletProvider = feeRelayWallet
-        ? {
-            ...walletProvider,
-            balanceTx: async (tx, ttl) => {
-              const txTtl = ttl ?? new Date(Date.now() + 30 * 60 * 1000);
-              const recipe = await feeWalletCtx.wallet.balanceUnboundTransaction(
-                tx,
-                {
-                  shieldedSecretKeys: feeWalletCtx.shieldedSecretKeys,
-                  dustSecretKey: feeWalletCtx.dustSecretKey,
-                },
-                { ttl: txTtl },
-              );
-              return await feeWalletCtx.wallet.finalizeRecipe(recipe);
-            },
-          }
-        : walletProvider;
-
-      const effectiveMidnightProvider: MidnightProvider = feeRelayWallet
-        ? { submitTx: async (tx) => await feeWalletCtx.wallet.submitTransaction(tx) }
-        : midnightProvider;
+      const { walletProvider: effectiveWalletProvider, midnightProvider: effectiveMidnightProvider } = feeRelayWallet
+        ? FeeRelay.applySeedRelay(feeWalletCtx, walletProvider, { txTtlMs })
+        : { walletProvider, midnightProvider };
 
       return {
         walletProvider: effectiveWalletProvider,
@@ -379,10 +358,114 @@ function createBaseProvidersEffect(
 }
 
 // =============================================================================
+// Wallet Acquisition Helpers
+// =============================================================================
+
+/**
+ * Init + sync a wallet.
+ * On success, caller owns the WalletContext and is responsible for closing it.
+ * On failure, no cleanup is performed — use the Scoped variant if you want
+ * automatic resource management.
+ */
+function initWalletEffect(
+  seed: string,
+  networkConfig: Config.NetworkConfig,
+  label: string,
+): Effect.Effect<Wallet.WalletContext, ClientError> {
+  return Effect.gen(function* () {
+    yield* Effect.logDebug(`Initializing ${label}...`);
+    const ctx = yield* Wallet.effect.init(seed, networkConfig).pipe(
+      Effect.mapError(
+        (e) =>
+          new ClientError({
+            cause: e,
+            message: `Failed to initialize ${label}: ${e.message}`,
+          }),
+      ),
+    );
+
+    yield* Wallet.effect.waitForSync(ctx).pipe(
+      Effect.mapError(
+        (e) =>
+          new ClientError({
+            cause: e,
+            message: `Failed to sync ${label}: ${e.message}`,
+          }),
+      ),
+    );
+    yield* Effect.logDebug(`${label} synced`);
+    return ctx;
+  });
+}
+
+// =============================================================================
+// Shared Helpers
+// =============================================================================
+
+/**
+ * ConnectedWallet path — builds providers from a pre-created wallet.
+ * No owned resources.
+ */
+function createConnectedWalletProviders(
+  connectedWallet: Wallet.ConnectedWallet,
+  networkConfig: Config.NetworkConfig,
+  privateStateProvider: PrivateStateProvider,
+  feeRelay?: { seed: string } | { url: string },
+): Effect.Effect<BaseProviders, ClientError> {
+  return Effect.gen(function* () {
+    yield* Effect.logDebug('Using pre-created wallet...');
+
+    let { walletProvider, midnightProvider } = yield* connectedWallet.effect.providers().pipe(
+      Effect.mapError(
+        (e) =>
+          new ClientError({
+            cause: e,
+            message: `Failed to get wallet providers: ${e.message}`,
+          }),
+      ),
+    );
+
+    if (feeRelay && 'url' in feeRelay) {
+      yield* Effect.logDebug(`Using fee relay server at ${feeRelay.url}`);
+      ({ walletProvider, midnightProvider } = FeeRelay.applyHttpRelay(feeRelay.url, walletProvider));
+    } else if (feeRelay && 'seed' in feeRelay) {
+      return yield* Effect.fail(
+        new ClientError({
+          cause: new Error('Seed-based fee relay not supported with ConnectedWallet'),
+          message: 'Seed-based fee relay ({ seed }) is not supported with a pre-created wallet. Use { url } for browser wallets.',
+        }),
+      );
+    }
+
+    setNetworkId(networkConfig.networkId as 'undeployed');
+    const publicDataProvider = Config.publicDataProvider(networkConfig);
+
+    return {
+      walletProvider,
+      midnightProvider,
+      publicDataProvider,
+      privateStateProvider,
+      networkConfig,
+    };
+  });
+}
+
+/** Extract NetworkConfig from a WalletConnection. */
+function connectionNetworkConfig(connection: Wallet.WalletConnection): Config.NetworkConfig {
+  return {
+    networkId: connection.config.networkId,
+    indexer: connection.config.indexerUri,
+    indexerWS: connection.config.indexerWsUri,
+    node: connection.config.substrateNodeUri,
+    proofServer: connection.config.proverServerUri ?? '',
+  };
+}
+
+// =============================================================================
 // Client Effect Implementations
 // =============================================================================
 
-function createClientDataEffect(config: ClientConfig): Effect.Effect<ClientData, ClientError> {
+function createEffect(config: ClientConfig): Effect.Effect<MiddayClient, ClientError> {
   return Effect.gen(function* () {
     const {
       network = 'local',
@@ -393,119 +476,20 @@ function createClientDataEffect(config: ClientConfig): Effect.Effect<ClientData,
       storage,
       logging = true,
       feeRelay,
+      txTtlMs,
     } = config;
 
     const networkConfig = customNetworkConfig ?? Config.getNetworkConfig(network);
 
-    // Path 1: Pre-created ConnectedWallet
+    // Path 1: Pre-created ConnectedWallet (no owned resources)
     if (connectedWallet) {
-      yield* Effect.logDebug('Using pre-created wallet...');
-
-      let { walletProvider, midnightProvider } = yield* connectedWallet.effect.providers().pipe(
-        Effect.mapError(
-          (e) =>
-            new ClientError({
-              cause: e,
-              message: `Failed to get wallet providers: ${e.message}`,
-            }),
-        ),
+      const providers = yield* createConnectedWalletProviders(
+        connectedWallet, networkConfig, privateStateProvider, feeRelay,
       );
-
-      // Apply fee relay override if configured
-      if (feeRelay && 'url' in feeRelay) {
-        const relayUrl = feeRelay.url.replace(/\/$/, '');
-        yield* Effect.logDebug(`Using fee relay server at ${relayUrl}`);
-
-        walletProvider = {
-          ...walletProvider,
-          balanceTx: async (tx) => {
-            // Serialize the UnboundTransaction to hex for the fee relay
-            // The browser WASM and fee relay WASM must use compatible serialization
-            let txHex: string;
-            try {
-              const txBytes = tx.serialize();
-              txHex = bytesToHex(txBytes);
-            } catch (serializeErr) {
-              throw new Error(
-                `Failed to serialize transaction for fee relay: ${serializeErr instanceof Error ? serializeErr.message : String(serializeErr)}`,
-              );
-            }
-
-            const response = await fetch(`${relayUrl}/balance-tx`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ tx: txHex }),
-            });
-            if (!response.ok) {
-              const err = await response.json().catch(() => ({ error: response.statusText }));
-              throw new Error(`Fee relay balance-tx failed: ${err.error}`);
-            }
-
-            const data = await response.json();
-            if (!data.tx) {
-              throw new Error('Fee relay returned empty tx');
-            }
-
-            const finalizedBytes = hexToBytes(data.tx);
-            // Use the same deserialize pattern as the Docker fee relay server
-            return Transaction.deserialize(
-              'signature' as import('@midnight-ntwrk/ledger-v7').SignatureEnabled['instance'],
-              'proof' as import('@midnight-ntwrk/ledger-v7').Proof['instance'],
-              'binding' as import('@midnight-ntwrk/ledger-v7').Binding['instance'],
-              finalizedBytes,
-            ) as unknown as import('@midnight-ntwrk/ledger-v7').FinalizedTransaction;
-          },
-        };
-        midnightProvider = {
-          submitTx: async (tx) => {
-            const txBytes = tx.serialize();
-            const txHex = bytesToHex(txBytes);
-
-            const response = await fetch(`${relayUrl}/submit-tx`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ tx: txHex }),
-            });
-            if (!response.ok) {
-              const err = await response.json().catch(() => ({ error: response.statusText }));
-              throw new Error(`Fee relay submit-tx failed: ${err.error}`);
-            }
-
-            const { txId } = await response.json();
-            return txId;
-          },
-        };
-      } else if (feeRelay && 'seed' in feeRelay) {
-        return yield* Effect.fail(
-          new ClientError({
-            cause: new Error('Seed-based fee relay not supported with ConnectedWallet'),
-            message: 'Seed-based fee relay ({ seed }) is not supported with a pre-created wallet. Use { url } for browser wallets.',
-          }),
-        );
-      }
-
-      setNetworkId(networkConfig.networkId as 'undeployed');
-      const publicDataProvider = Config.publicDataProvider(networkConfig);
-
-      const providers: BaseProviders = {
-        walletProvider,
-        midnightProvider,
-        publicDataProvider,
-        privateStateProvider,
-        networkConfig,
-      };
-
-      return {
-        wallet: null,
-        connectedWallet,
-        relayerWallet: null,
-        networkConfig,
-        providers,
-        logging,
-      };
+      return buildClient({ networkConfig, providers, logging });
     }
 
-    // Path 2: Legacy seed-based initialization
+    // Path 2: Seed-based initialization
     const walletSeed = seed ?? (network === 'local' ? Config.DEV_WALLET_SEED : undefined);
     if (!walletSeed) {
       return yield* Effect.fail(
@@ -516,53 +500,7 @@ function createClientDataEffect(config: ClientConfig): Effect.Effect<ClientData,
       );
     }
 
-    yield* Effect.logDebug('Initializing wallet...');
-    const walletContext = yield* Wallet.effect.init(walletSeed, networkConfig).pipe(
-      Effect.mapError(
-        (e) =>
-          new ClientError({
-            cause: e,
-            message: `Failed to initialize wallet: ${e.message}`,
-          }),
-      ),
-    );
-
-    yield* Wallet.effect.waitForSync(walletContext).pipe(
-      Effect.mapError(
-        (e) =>
-          new ClientError({
-            cause: e,
-            message: `Failed to sync wallet: ${e.message}`,
-          }),
-      ),
-    );
-    yield* Effect.logDebug('Wallet synced');
-
-    // Initialize fee relay wallet if configured (seed-based only for Client.create)
-    let relayerWallet: WalletContext | null = null;
-    if (feeRelay && 'seed' in feeRelay) {
-      yield* Effect.logDebug('Initializing fee relay wallet...');
-      relayerWallet = yield* Wallet.effect.init(feeRelay.seed, networkConfig).pipe(
-        Effect.mapError(
-          (e) =>
-            new ClientError({
-              cause: e,
-              message: `Failed to initialize fee relay wallet: ${e.message}`,
-            }),
-        ),
-      );
-
-      yield* Wallet.effect.waitForSync(relayerWallet).pipe(
-        Effect.mapError(
-          (e) =>
-            new ClientError({
-              cause: e,
-              message: `Failed to sync fee relay wallet: ${e.message}`,
-            }),
-        ),
-      );
-      yield* Effect.logDebug('Fee relay wallet synced');
-    } else if (feeRelay && 'url' in feeRelay) {
+    if (feeRelay && 'url' in feeRelay) {
       return yield* Effect.fail(
         new ClientError({
           cause: new Error('URL-based fee relay not supported with Client.create'),
@@ -571,149 +509,63 @@ function createClientDataEffect(config: ClientConfig): Effect.Effect<ClientData,
       );
     }
 
-    const providerOptions: CreateBaseProvidersOptions = {
+    const walletContext = yield* initWalletEffect(walletSeed, networkConfig, 'wallet');
+
+    let relayerWallet: Wallet.WalletContext | null = null;
+    if (feeRelay && 'seed' in feeRelay) {
+      relayerWallet = yield* initWalletEffect(feeRelay.seed, networkConfig, 'fee relay wallet');
+    }
+
+    const providers = yield* createBaseProvidersEffect(walletContext, {
       networkConfig,
       privateStateProvider,
       storageConfig: storage,
       feeRelayWallet: relayerWallet ?? undefined,
-    };
+      txTtlMs,
+    });
 
-    const providers = yield* createBaseProvidersEffect(walletContext, providerOptions);
-
-    return {
-      wallet: walletContext,
-      connectedWallet: null,
-      relayerWallet,
+    return buildClient({
       networkConfig,
       providers,
       logging,
-    };
+      close: Effect.gen(function* () {
+        if (relayerWallet) yield* Wallet.effect.close(relayerWallet);
+        yield* Wallet.effect.close(walletContext);
+      }).pipe(
+        Effect.mapError(
+          (e) => new ClientError({ cause: e, message: `Failed to close client: ${e.message}` }),
+        ),
+      ),
+    });
   });
 }
 
-function fromWalletDataEffect(
-  connection: WalletConnection,
-  config: {
-    privateStateProvider: PrivateStateProvider;
-    logging?: boolean;
-    feeRelay?: { seed: string } | { url: string };
-  },
-): Effect.Effect<ClientData, ClientError> {
+function fromWalletEffect(
+  connection: Wallet.WalletConnection,
+  config: FromWalletConfig,
+): Effect.Effect<MiddayClient, ClientError> {
   return Effect.gen(function* () {
-    const { privateStateProvider, logging = true, feeRelay } = config;
+    const { privateStateProvider, logging = true, feeRelay, txTtlMs } = config;
+    const networkConfig = connectionNetworkConfig(connection);
 
-    const networkConfig: NetworkConfig = {
-      networkId: connection.config.networkId,
-      indexer: connection.config.indexerUri,
-      indexerWS: connection.config.indexerWsUri,
-      node: connection.config.substrateNodeUri,
-      proofServer: connection.config.proverServerUri ?? '',
-    };
+    let relayerWallet: Wallet.WalletContext | null = null;
+    if (feeRelay && 'seed' in feeRelay) {
+      relayerWallet = yield* initWalletEffect(feeRelay.seed, networkConfig, 'fee relay wallet');
+    }
 
-    // Create wallet providers from connection
     let { walletProvider, midnightProvider } = Wallet.createWalletProviders(connection.wallet, connection.addresses);
 
-    // Initialize fee relay if configured
-    let relayerWallet: WalletContext | null = null;
-    if (feeRelay && 'seed' in feeRelay) {
-      // Seed-based: initialize a local wallet (Node.js)
-      yield* Effect.logDebug('Initializing fee relay wallet...');
-      relayerWallet = yield* Wallet.effect.init(feeRelay.seed, networkConfig).pipe(
-        Effect.mapError(
-          (e) =>
-            new ClientError({
-              cause: e,
-              message: `Failed to initialize fee relay wallet: ${e.message}`,
-            }),
-        ),
-      );
-
-      yield* Wallet.effect.waitForSync(relayerWallet).pipe(
-        Effect.mapError(
-          (e) =>
-            new ClientError({
-              cause: e,
-              message: `Failed to sync fee relay wallet: ${e.message}`,
-            }),
-        ),
-      );
-      yield* Effect.logDebug('Fee relay wallet synced');
-
-      // Override balanceTx/submitTx to use relay wallet, keep Lace's ZK keys
-      const relayCtx = relayerWallet;
-      walletProvider = {
-        ...walletProvider,
-        balanceTx: async (tx, ttl) => {
-          const txTtl = ttl ?? new Date(Date.now() + 30 * 60 * 1000);
-          const recipe = await relayCtx.wallet.balanceUnboundTransaction(
-            tx,
-            {
-              shieldedSecretKeys: relayCtx.shieldedSecretKeys,
-              dustSecretKey: relayCtx.dustSecretKey,
-            },
-            { ttl: txTtl },
-          );
-          return await relayCtx.wallet.finalizeRecipe(recipe);
-        },
-      };
-      midnightProvider = {
-        submitTx: async (tx) => await relayCtx.wallet.submitTransaction(tx),
-      };
+    if (relayerWallet && feeRelay && 'seed' in feeRelay) {
+      ({ walletProvider, midnightProvider } = FeeRelay.applySeedRelay(relayerWallet, walletProvider, { txTtlMs }));
     } else if (feeRelay && 'url' in feeRelay) {
-      // URL-based: proxy to a remote fee relay server (browser)
-      const relayUrl = feeRelay.url.replace(/\/$/, '');
-      yield* Effect.logDebug(`Using fee relay server at ${relayUrl}`);
-
-      walletProvider = {
-        ...walletProvider,
-        balanceTx: async (tx) => {
-          const txBytes = tx.serialize();
-          const txHex = bytesToHex(txBytes);
-
-          const response = await fetch(`${relayUrl}/balance-tx`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ tx: txHex }),
-          });
-          if (!response.ok) {
-            const err = await response.json().catch(() => ({ error: response.statusText }));
-            throw new Error(`Fee relay balance-tx failed: ${err.error}`);
-          }
-
-          const { tx: finalizedHex } = await response.json();
-          const finalizedBytes = hexToBytes(finalizedHex);
-          return Transaction.deserialize(
-            'signature' as import('@midnight-ntwrk/ledger-v7').SignatureEnabled['instance'],
-            'proof' as import('@midnight-ntwrk/ledger-v7').Proof['instance'],
-            'binding' as import('@midnight-ntwrk/ledger-v7').Binding['instance'],
-            finalizedBytes,
-          ) as unknown as import('@midnight-ntwrk/ledger-v7').FinalizedTransaction;
-        },
-      };
-      midnightProvider = {
-        submitTx: async (tx) => {
-          const txBytes = tx.serialize();
-          const txHex = bytesToHex(txBytes);
-
-          const response = await fetch(`${relayUrl}/submit-tx`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ tx: txHex }),
-          });
-          if (!response.ok) {
-            const err = await response.json().catch(() => ({ error: response.statusText }));
-            throw new Error(`Fee relay submit-tx failed: ${err.error}`);
-          }
-
-          const { txId } = await response.json();
-          return txId;
-        },
-      };
+      yield* Effect.logDebug(`Using fee relay server at ${feeRelay.url}`);
+      ({ walletProvider, midnightProvider } = FeeRelay.applyHttpRelay(feeRelay.url, walletProvider));
     }
 
     setNetworkId(networkConfig.networkId as 'undeployed');
-
     const publicDataProvider = Config.publicDataProvider(networkConfig);
+
+    yield* Effect.logDebug('Connected to wallet');
 
     const providers: BaseProviders = {
       walletProvider,
@@ -723,16 +575,18 @@ function fromWalletDataEffect(
       networkConfig,
     };
 
-    yield* Effect.logDebug('Connected to wallet');
-
-    return {
-      wallet: null,
-      connectedWallet: null,
-      relayerWallet,
+    return buildClient({
       networkConfig,
       providers,
       logging,
-    };
+      close: relayerWallet
+        ? Wallet.effect.close(relayerWallet).pipe(
+            Effect.mapError(
+              (e) => new ClientError({ cause: e, message: `Failed to close client: ${e.message}` }),
+            ),
+          )
+        : undefined,
+    });
   }).pipe(
     Effect.catchAllDefect((defect) =>
       Effect.fail(
@@ -745,147 +599,85 @@ function fromWalletDataEffect(
   );
 }
 
-function loadContractEffect(
-  clientData: ClientData,
-  options: LoadContractOptions,
-): Effect.Effect<LoadedContractData, ClientError> {
-  return loadContractModuleEffect(
-    options,
-    clientData.providers.networkConfig,
-    clientData.providers,
-    clientData.logging,
-  ).pipe(
-    Effect.mapError(
-      (e) =>
-        new ClientError({
-          cause: e,
-          message: e.message,
-        }),
-    ),
-  );
-}
-
-function waitForTxEffect(
-  clientData: ClientData,
-  txHash: string,
-  options?: WaitForTxOptions,
-): Effect.Effect<FinalizedTxData, ClientError | TxTimeoutError> {
-  const base = Effect.tryPromise({
-    try: async () => {
-      const data = await clientData.providers.publicDataProvider.watchForTxData(txHash);
-      return {
-        txHash: data.txHash,
-        blockHeight: data.blockHeight,
-        blockHash: data.blockHash,
-      };
-    },
-    catch: (cause) =>
-      new ClientError({
-        cause,
-        message: `Failed to wait for transaction: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
-  });
-
-  if (options?.timeout != null) {
-    return Effect.timeoutFail(base, {
-      duration: Duration.millis(options.timeout),
-      onTimeout: () =>
-        new TxTimeoutError({
-          txHash,
-          timeout: options.timeout!,
-          message: `Transaction ${txHash} was not finalized within ${options.timeout}ms`,
-        }),
-    });
-  }
-
-  return base;
-}
-
-function closeClientEffect(data: ClientData): Effect.Effect<void, ClientError> {
-  return Effect.gen(function* () {
-    if (data.relayerWallet) {
-      yield* Wallet.effect.close(data.relayerWallet).pipe(
-        Effect.mapError(
-          (e) =>
-            new ClientError({
-              cause: e,
-              message: `Failed to close fee relay wallet: ${e.message}`,
-            }),
-        ),
-      );
-    }
-    if (data.wallet) {
-      yield* Wallet.effect.close(data.wallet).pipe(
-        Effect.mapError(
-          (e) =>
-            new ClientError({
-              cause: e,
-              message: `Failed to close wallet: ${e.message}`,
-            }),
-        ),
-      );
-    }
-    if (data.connectedWallet) {
-      yield* data.connectedWallet.effect.close().pipe(
-        Effect.mapError(
-          (e) =>
-            new ClientError({
-              cause: e,
-              message: `Failed to close wallet: ${e.message}`,
-            }),
-        ),
-      );
-    }
-  });
-}
-
 // =============================================================================
 // Handle Factory
 // =============================================================================
 
-function createClientHandle(data: ClientData): MiddayClient {
-  return {
-    networkConfig: data.networkConfig,
-    providers: data.providers,
-    wallet: data.wallet,
-    relayerWallet: data.relayerWallet,
+function buildClient(args: {
+  networkConfig: Config.NetworkConfig;
+  providers: BaseProviders;
+  logging: boolean;
+  close?: Effect.Effect<void, ClientError>;
+}): MiddayClient {
+  const { networkConfig, providers, logging, close: closeEff = Effect.void } = args;
 
-    loadContract: async <M extends ContractModule>(options: LoadContractOptions<M>) => {
-      const contractData = await runEffectWithLogging(
-        loadContractEffect(data, options),
-        data.logging,
-      );
-      return createLoadedContractHandle(contractData) as LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>;
+  const loadContractEff = (options: Contract.LoadContractOptions) =>
+    Contract.loadContractModuleEffect(options, networkConfig, providers, logging).pipe(
+      Effect.mapError((e) => new ClientError({ cause: e, message: e.message })),
+    );
+
+  const waitForTxEff = (txHash: string, options?: WaitForTxOptions) => {
+    const base = Effect.tryPromise({
+      try: async () => {
+        const data = await providers.publicDataProvider.watchForTxData(txHash);
+        return { txHash: data.txHash, blockHeight: data.blockHeight, blockHash: data.blockHash };
+      },
+      catch: (cause) =>
+        new ClientError({
+          cause,
+          message: `Failed to wait for transaction: ${cause instanceof Error ? cause.message : String(cause)}`,
+        }),
+    });
+
+    if (options?.timeout != null) {
+      return Effect.timeoutFail(base, {
+        duration: Duration.millis(options.timeout),
+        onTimeout: () =>
+          new TxTimeoutError({
+            txHash,
+            timeout: options.timeout!,
+            message: `Transaction ${txHash} was not finalized within ${options.timeout}ms`,
+          }),
+      });
+    }
+
+    return base;
+  };
+
+  return {
+    networkConfig,
+    providers,
+
+    loadContract: async <M extends Contract.ContractModule>(options: Contract.LoadContractOptions<M>) => {
+      const contractData = await Runtime.runEffectWithLogging(loadContractEff(options), logging);
+      return Contract.createLoadedContractHandle(contractData) as Contract.LoadedContract<Contract.InferLedger<M>, Contract.InferCircuits<M>, Contract.InferActions<M>>;
     },
     waitForTx: (txHash, options?) =>
-      runEffectWithLogging(waitForTxEffect(data, txHash, options), data.logging),
-    close: () =>
-      runEffectWithLogging(closeClientEffect(data), data.logging),
-
-    [Symbol.asyncDispose]: () =>
-      runEffectWithLogging(closeClientEffect(data), data.logging),
+      Runtime.runEffectWithLogging(waitForTxEff(txHash, options), logging),
+    close: () => Runtime.runEffectWithLogging(closeEff, logging),
+    [Symbol.asyncDispose]: () => Runtime.runEffectWithLogging(closeEff, logging),
 
     effect: {
-      loadContract: <M extends ContractModule>(options: LoadContractOptions<M>) =>
-        loadContractEffect(data, options).pipe(
-          Effect.map((contractData) => createLoadedContractHandle(contractData) as LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>),
+      loadContract: <M extends Contract.ContractModule>(options: Contract.LoadContractOptions<M>) =>
+        loadContractEff(options).pipe(
+          Effect.map((contractData) => Contract.createLoadedContractHandle(contractData) as Contract.LoadedContract<Contract.InferLedger<M>, Contract.InferCircuits<M>, Contract.InferActions<M>>),
         ),
-      waitForTx: (txHash, options?) => waitForTxEffect(data, txHash, options),
-      close: () => closeClientEffect(data),
+      waitForTx: (txHash, options?) => waitForTxEff(txHash, options),
+      close: () => closeEff,
     },
   };
 }
 
-function createReadonlyClientHandle(
-  networkConfig: NetworkConfig,
-  provider: PublicDataProvider,
+function createReadonlyHandle(
+  networkConfig: Config.NetworkConfig,
+  provider: Contract.PublicDataProvider,
 ): ReadonlyClient {
   return {
     networkConfig,
     provider,
 
-    loadContract: <M extends ContractModule>(options: { module: M }) =>
-      createReadonlyContractHandle(options.module.ledger, provider) as ReadonlyContract<InferLedger<M>>,
+    loadContract: <M extends Contract.ContractModule>(options: { module: M }) =>
+      Contract.createReadonlyContractHandle(options.module.ledger, provider) as Contract.ReadonlyContract<Contract.InferLedger<M>>,
   };
 }
 
@@ -914,13 +706,14 @@ function createReadonlyClientHandle(
  * const state = await deployed.ledgerState();
  * ```
  *
+ * **Constraint:** Only one network ID is supported per process — see {@link ClientConfig}.
+ *
  * @since 0.2.0
  * @category constructors
  */
 export async function create(config: ClientConfig): Promise<MiddayClient> {
   const logging = config.logging ?? true;
-  const data = await runEffectWithLogging(createClientDataEffect(config), logging);
-  return createClientHandle(data);
+  return Runtime.runEffectWithLogging(createEffect(config), logging);
 }
 
 /**
@@ -947,7 +740,7 @@ export async function create(config: ClientConfig): Promise<MiddayClient> {
 export function createReadonly(config: ReadonlyClientConfig = {}): ReadonlyClient {
   const networkConfig = config.networkConfig ?? Config.getNetworkConfig(config.network ?? 'local');
   const provider = Config.publicDataProvider(networkConfig);
-  return createReadonlyClientHandle(networkConfig, provider);
+  return createReadonlyHandle(networkConfig, provider);
 }
 
 /**
@@ -971,20 +764,19 @@ export async function withClient<A>(
 /**
  * Create a Midnight client from a connected wallet (browser).
  *
+ * Both fee relay variants are supported here:
+ * - `{ seed }` — initialises a local relay wallet (Node.js integration tests)
+ * - `{ url }` — proxies to a remote HTTP fee relay server (browser)
+ *
  * @since 0.2.0
  * @category constructors
  */
 export async function fromWallet(
-  connection: WalletConnection,
-  config: {
-    privateStateProvider: PrivateStateProvider;
-    logging?: boolean;
-    feeRelay?: { seed: string } | { url: string };
-  },
+  connection: Wallet.WalletConnection,
+  config: FromWalletConfig,
 ): Promise<MiddayClient> {
   const logging = config.logging ?? true;
-  const data = await runEffectWithLogging(fromWalletDataEffect(connection, config), logging);
-  return createClientHandle(data);
+  return Runtime.runEffectWithLogging(fromWalletEffect(connection, config), logging);
 }
 
 /**
@@ -995,12 +787,12 @@ export async function fromWallet(
  */
 export const effect = {
   create: (config: ClientConfig): Effect.Effect<MiddayClient, ClientError> =>
-    createClientDataEffect(config).pipe(Effect.map(createClientHandle)),
+    createEffect(config),
 
   createScoped: (config: ClientConfig): Effect.Effect<MiddayClient, ClientError, Scope.Scope> =>
     Effect.acquireRelease(
-      createClientDataEffect(config).pipe(Effect.map(createClientHandle)),
-      (client) => client.effect.close().pipe(Effect.catchAll(() => Effect.void)),
+      createEffect(config),
+      (client) => client.effect.close().pipe(Effect.orDie),
     ),
 
   withClient: <A, E>(
@@ -1009,20 +801,25 @@ export const effect = {
   ): Effect.Effect<A, E | ClientError> =>
     Effect.scoped(
       Effect.acquireRelease(
-        createClientDataEffect(config).pipe(Effect.map(createClientHandle)),
-        (client) => client.effect.close().pipe(Effect.catchAll(() => Effect.void)),
+        createEffect(config),
+        (client) => client.effect.close().pipe(Effect.orDie),
       ).pipe(Effect.flatMap(body)),
     ),
 
   fromWallet: (
-    connection: WalletConnection,
-    config: {
-      privateStateProvider: PrivateStateProvider;
-      logging?: boolean;
-      feeRelay?: { seed: string } | { url: string };
-    },
+    connection: Wallet.WalletConnection,
+    config: FromWalletConfig,
   ): Effect.Effect<MiddayClient, ClientError> =>
-    fromWalletDataEffect(connection, config).pipe(Effect.map(createClientHandle)),
+    fromWalletEffect(connection, config),
+
+  fromWalletScoped: (
+    connection: Wallet.WalletConnection,
+    config: FromWalletConfig,
+  ): Effect.Effect<MiddayClient, ClientError, Scope.Scope> =>
+    Effect.acquireRelease(
+      fromWalletEffect(connection, config),
+      (client) => client.effect.close().pipe(Effect.orDie),
+    ),
 
   createReadonly: (config: ReadonlyClientConfig = {}): ReadonlyClient =>
     createReadonly(config),
@@ -1031,43 +828,6 @@ export const effect = {
 // =============================================================================
 // Effect DI
 // =============================================================================
-
-/**
- * Service interface for Client operations.
- *
- * @since 0.2.0
- * @category service
- */
-export interface ClientServiceImpl {
-  readonly create: (config: ClientConfig) => Effect.Effect<MiddayClient, ClientError>;
-  readonly fromWallet: (
-    connection: WalletConnection,
-    config: {
-      privateStateProvider: PrivateStateProvider;
-      logging?: boolean;
-      feeRelay?: { seed: string } | { url: string };
-    },
-  ) => Effect.Effect<MiddayClient, ClientError>;
-}
-
-/**
- * Context.Tag for ClientService dependency injection.
- *
- * @since 0.2.0
- * @category service
- */
-export class ClientService extends Context.Tag('ClientService')<ClientService, ClientServiceImpl>() {}
-
-/**
- * Live Layer for ClientService.
- *
- * @since 0.2.0
- * @category layer
- */
-export const ClientLive: Layer.Layer<ClientService> = Layer.succeed(ClientService, {
-  create: effect.create,
-  fromWallet: effect.fromWallet,
-});
 
 /**
  * Context.Tag for a pre-initialized MiddayClient.
@@ -1098,29 +858,8 @@ export function layer(config: ClientConfig): Layer.Layer<MiddayClientService, Cl
  * @category layer
  */
 export function layerFromWallet(
-  connection: WalletConnection,
-  config: {
-    zkConfigProvider: ZKConfigProvider<string>;
-    privateStateProvider: PrivateStateProvider;
-    logging?: boolean;
-    feeRelay?: { seed: string } | { url: string };
-  },
+  connection: Wallet.WalletConnection,
+  config: FromWalletConfig,
 ): Layer.Layer<MiddayClientService, ClientError> {
-  return Layer.scoped(
-    MiddayClientService,
-    Effect.acquireRelease(
-      effect.fromWallet(connection, config),
-      (client) => client.effect.close().pipe(Effect.catchAll(() => Effect.void)),
-    ),
-  );
-}
-
-/**
- * Create a Layer providing all Client-related services.
- *
- * @since 0.3.0
- * @category layer
- */
-export function services(): Layer.Layer<ClientService> {
-  return ClientLive;
+  return Layer.scoped(MiddayClientService, effect.fromWalletScoped(connection, config));
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -60,6 +60,17 @@ export function getNetworkConfig(network: string = 'local'): NetworkConfig {
  */
 export const DEV_WALLET_SEED = '0000000000000000000000000000000000000000000000000000000000000001';
 
+/**
+ * Default transaction TTL in milliseconds (30 minutes).
+ *
+ * Used as the fallback when no per-call `ttl` is provided to `balanceTx`.
+ * Configurable via `txTtlMs` on `ClientConfig`.
+ *
+ * @since 0.12.0
+ * @category constants
+ */
+export const DEFAULT_TX_TTL_MS = 30 * 60 * 1000;
+
 // =============================================================================
 // Provider Factories
 // =============================================================================

--- a/src/Contract.ts
+++ b/src/Contract.ts
@@ -10,13 +10,13 @@
  * // Promise user
  * const contract = await client.loadContract({ path: './contracts/counter' });
  * await contract.deploy();
- * await contract.call('increment');
+ * await contract.actions.increment();
  * const state = await contract.ledgerState();
  *
  * // Effect user
  * const contract = yield* client.effect.loadContract({ path: './contracts/counter' });
  * yield* contract.effect.deploy();
- * yield* contract.effect.call('increment');
+ * yield* contract.effect.actions.increment();
  * ```
  *
  * @since 0.3.0
@@ -126,7 +126,7 @@ export type InferCircuits<M> = M extends {
  * @since 0.8.0
  * @category type
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 export type InferActions<M> = M extends {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Contract: new (...args: any[]) => { impureCircuits: infer IC };
@@ -136,6 +136,37 @@ export type InferActions<M> = M extends {
     ? (...args: A) => Promise<CallResult>
     : (...args: unknown[]) => Promise<CallResult>;
 } : Record<string, (...args: unknown[]) => Promise<CallResult>>;
+
+/**
+ * Shorthand for `LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>`.
+ *
+ * @example
+ * ```typescript
+ * import * as CounterContract from './contracts/counter/contract/index.js';
+ * let loaded: LoadedContractFor<typeof CounterContract>;
+ * ```
+ *
+ * @since 0.12.0
+ * @category type
+ */
+export type LoadedContractFor<M extends ContractModule> =
+  LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>;
+
+/**
+ * Shorthand for `DeployedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>`.
+ *
+ * @example
+ * ```typescript
+ * import * as CounterContract from './contracts/counter/contract/index.js';
+ * let contract: DeployedContractFor<typeof CounterContract>;
+ * // contract.ledgerState() returns Promise<{ counter: bigint }>
+ * ```
+ *
+ * @since 0.12.0
+ * @category type
+ */
+export type DeployedContractFor<M extends ContractModule> =
+  DeployedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>;
 
 /**
  * Convert Promise-based actions to Effect-based actions.
@@ -264,15 +295,6 @@ export interface CallResult {
 }
 
 /**
- * Contract state: either "loaded" (pre-deploy) or "deployed" (connected to network).
- *
- * @deprecated Use `LoadedContract` and `DeployedContract` types instead.
- * @since 0.6.0
- * @category model
- */
-export type ContractState = 'loaded' | 'deployed';
-
-/**
  * Full providers for a contract (includes zkConfig and proofProvider).
  *
  * @since 0.3.0
@@ -369,7 +391,6 @@ export interface DeployedContract<
    *
    * @example
    * ```typescript
-   * // Instead of: await contract.call('increment', 5n)
    * await contract.actions.increment(5n);
    * ```
    *
@@ -499,20 +520,6 @@ export interface ReadonlyContract<TLedger = unknown> {
   };
 }
 
-/**
- * Legacy unified contract type.
- *
- * @deprecated Use `LoadedContract` and `DeployedContract` separately.
- * @since 0.2.6
- * @category model
- */
-export type Contract<
-  TLedger = unknown,
-  TCircuits extends string = string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TActions extends Record<string, (...args: any[]) => Promise<CallResult>> = Record<string, (...args: unknown[]) => Promise<CallResult>>,
-> = LoadedContract<TLedger, TCircuits, TActions> | DeployedContract<TLedger, TCircuits, TActions>;
-
 // =============================================================================
 // Internal Data
 // =============================================================================
@@ -535,16 +542,6 @@ export interface DeployedContractData extends LoadedContractData {
   readonly address: string;
   readonly instance: DeployedContractInstance;
 }
-
-/**
- * Legacy alias.
- * @deprecated Use `LoadedContractData` or `DeployedContractData`.
- * @internal
- */
-export type ContractData = LoadedContractData & {
-  readonly address: string | undefined;
-  readonly instance: unknown | undefined;
-};
 
 /**
  * Internal interface for deployed contract instance with callable transaction methods.
@@ -1274,7 +1271,7 @@ export interface CreateContractOptions<M extends ContractModule = ContractModule
  */
 function createContractEffect<M extends ContractModule>(
   options: CreateContractOptions<M>,
-): Effect.Effect<LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>, ContractError> {
+): Effect.Effect<LoadedContractFor<M>, ContractError> {
   const {
     walletProvider,
     midnightProvider,
@@ -1298,7 +1295,7 @@ function createContractEffect<M extends ContractModule>(
     { proofServer: proofServerUrl },
     baseProviders,
     logging,
-  ).pipe(Effect.map((data) => createLoadedContractHandle(data) as LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>));
+  ).pipe(Effect.map((data) => createLoadedContractHandle(data) as LoadedContractFor<M>));
 }
 
 /**
@@ -1314,9 +1311,8 @@ function createContractEffect<M extends ContractModule>(
  * import * as Contract from '@no-witness-labs/midday-sdk/Contract';
  * import * as PrivateState from '@no-witness-labs/midday-sdk/PrivateState';
  *
- * const ctx = await Wallet.init(seed, networkConfig);
- * await Wallet.waitForSync(ctx);
- * const { walletProvider, midnightProvider } = Wallet.providers(ctx);
+ * const wallet = await Wallet.fromSeed(seed, networkConfig);
+ * const { walletProvider, midnightProvider } = wallet.providers();
  * const publicDataProvider = Config.publicDataProvider(networkConfig);
  * const privateStateProvider = PrivateState.inMemoryProvider();
  *
@@ -1330,7 +1326,7 @@ function createContractEffect<M extends ContractModule>(
  * });
  *
  * await contract.deploy();
- * await contract.call('increment');
+ * await contract.actions.increment();
  * ```
  *
  * @since 0.6.0
@@ -1338,7 +1334,7 @@ function createContractEffect<M extends ContractModule>(
  */
 export async function create<M extends ContractModule>(
   options: CreateContractOptions<M>,
-): Promise<LoadedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>> {
+): Promise<LoadedContractFor<M>> {
   const logging = options.logging ?? true;
   return runEffectWithLogging(createContractEffect(options), logging);
 }
@@ -1439,12 +1435,6 @@ export function createDeployedContractHandle(data: DeployedContractData): Deploy
     },
   };
 }
-
-/**
- * @deprecated Use `createLoadedContractHandle` instead.
- * @internal
- */
-export const createContractHandle = createLoadedContractHandle;
 
 /**
  * Create a ReadonlyContract handle from a ledger parser and provider.

--- a/src/FeeRelay.ts
+++ b/src/FeeRelay.ts
@@ -1,0 +1,163 @@
+/**
+ * Fee relay provider overrides.
+ *
+ * Centralises the logic for delegating `balanceTx` / `submitTx` to either
+ * a local seed-based relay wallet or a remote HTTP relay server. Used
+ * internally by {@link Client} — not part of the public API.
+ *
+ * @internal
+ * @since 0.11.0
+ * @module
+ */
+
+import { Transaction } from '@midnight-ntwrk/ledger-v7';
+import type {
+  WalletProvider,
+  MidnightProvider,
+} from '@midnight-ntwrk/midnight-js-types';
+
+import type { WalletContext } from './Wallet.js';
+import { bytesToHex, hexToBytes } from './Utils.js';
+import { DEFAULT_TX_TTL_MS } from './Config.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * The subset of provider overrides produced by fee relay helpers.
+ *
+ * @internal
+ */
+export interface FeeRelayProviders {
+  readonly walletProvider: WalletProvider;
+  readonly midnightProvider: MidnightProvider;
+}
+
+// =============================================================================
+// Seed-based relay
+// =============================================================================
+
+/**
+ * Override `balanceTx` and `submitTx` to use a pre-initialised relay wallet.
+ *
+ * The relay wallet pays fees (balance + submit), while the original wallet
+ * provider is preserved for ZK proof generation. This is the Node.js path.
+ *
+ * @param relayCtx  Pre-initialised and synced relay wallet context.
+ * @param baseWalletProvider  Original wallet provider (ZK proofs stay here).
+ * @returns Overridden provider pair.
+ *
+ * @internal
+ */
+export function applySeedRelay(
+  relayCtx: WalletContext,
+  baseWalletProvider: WalletProvider,
+  options?: { txTtlMs?: number },
+): FeeRelayProviders {
+  const defaultTtlMs = options?.txTtlMs ?? DEFAULT_TX_TTL_MS;
+  const walletProvider: WalletProvider = {
+    ...baseWalletProvider,
+    balanceTx: async (tx, ttl) => {
+      const txTtl = ttl ?? new Date(Date.now() + defaultTtlMs);
+      const recipe = await relayCtx.wallet.balanceUnboundTransaction(
+        tx,
+        {
+          shieldedSecretKeys: relayCtx.shieldedSecretKeys,
+          dustSecretKey: relayCtx.dustSecretKey,
+        },
+        { ttl: txTtl },
+      );
+      return await relayCtx.wallet.finalizeRecipe(recipe);
+    },
+  };
+
+  const midnightProvider: MidnightProvider = {
+    submitTx: async (tx) => await relayCtx.wallet.submitTransaction(tx),
+  };
+
+  return { walletProvider, midnightProvider };
+}
+
+// =============================================================================
+// HTTP-based relay
+// =============================================================================
+
+/**
+ * Override `balanceTx` and `submitTx` to proxy through a remote HTTP relay.
+ *
+ * Transactions are serialised to hex, sent to the relay server, and the
+ * response is deserialised back. This is the browser path (e.g. Lace wallet).
+ *
+ * @param relayUrl  Base URL of the fee relay server (trailing slash stripped).
+ * @param baseWalletProvider  Original wallet provider (ZK proofs stay here).
+ * @returns Overridden provider pair.
+ *
+ * @internal
+ */
+export function applyHttpRelay(
+  relayUrl: string,
+  baseWalletProvider: WalletProvider,
+): FeeRelayProviders {
+  const url = relayUrl.replace(/\/$/, '');
+
+  const walletProvider: WalletProvider = {
+    ...baseWalletProvider,
+    balanceTx: async (tx) => {
+      let txHex: string;
+      try {
+        const txBytes = tx.serialize();
+        txHex = bytesToHex(txBytes);
+      } catch (serializeErr) {
+        throw new Error(
+          `Failed to serialize transaction for fee relay: ${serializeErr instanceof Error ? serializeErr.message : String(serializeErr)}`,
+        );
+      }
+
+      const response = await fetch(`${url}/balance-tx`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tx: txHex }),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({ error: response.statusText }));
+        throw new Error(`Fee relay balance-tx failed: ${err.error}`);
+      }
+
+      const data = await response.json();
+      if (!data.tx) {
+        throw new Error('Fee relay returned empty tx');
+      }
+
+      const finalizedBytes = hexToBytes(data.tx);
+      return Transaction.deserialize(
+        'signature' as import('@midnight-ntwrk/ledger-v7').SignatureEnabled['instance'],
+        'proof' as import('@midnight-ntwrk/ledger-v7').Proof['instance'],
+        'binding' as import('@midnight-ntwrk/ledger-v7').Binding['instance'],
+        finalizedBytes,
+      ) as unknown as import('@midnight-ntwrk/ledger-v7').FinalizedTransaction;
+    },
+  };
+
+  const midnightProvider: MidnightProvider = {
+    submitTx: async (tx) => {
+      const txBytes = tx.serialize();
+      const txHex = bytesToHex(txBytes);
+
+      const response = await fetch(`${url}/submit-tx`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tx: txHex }),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({ error: response.statusText }));
+        throw new Error(`Fee relay submit-tx failed: ${err.error}`);
+      }
+
+      const { txId } = await response.json();
+      return txId;
+    },
+  };
+
+  return { walletProvider, midnightProvider };
+}

--- a/src/Hash.ts
+++ b/src/Hash.ts
@@ -132,7 +132,7 @@ export function field(value: bigint): Hash32 {
  * ```typescript
  * const passwordHash = Midday.Hash.password('my-secret-password');
  * // Use as initial ledger value in contract init
- * await Midday.Contract.call(contract, 'init', passwordHash);
+ * await contract.actions.init(passwordHash);
  * ```
  *
  * @since 0.3.0

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -5,16 +5,12 @@
  * into a single module. Both share WalletError and the same domain.
  *
  * **Seed Wallet** (server-side):
- * - `Wallet.init(seed, config)` — initialize from HD seed
- * - `Wallet.waitForSync(ctx)` — wait for wallet to sync
+ * - `Wallet.fromSeed(seed, config)` — create and sync a connected wallet
  * - `Wallet.deriveAddress(seed, networkId)` — derive address without connecting
- * - `Wallet.close(ctx)` — release resources
  *
  * **Browser Wallet** (Lace extension):
- * - `Wallet.connectWallet(networkId)` — connect to Lace browser extension
+ * - `Wallet.fromBrowser(networkId)` — connect to Lace browser extension
  * - `Wallet.isWalletAvailable()` — check if extension is installed
- * - `Wallet.disconnectWallet()` — disconnect from wallet
- * - `Wallet.createWalletProviders(wallet, addresses)` — create tx providers
  *
  * @since 0.3.0
  * @module
@@ -37,7 +33,7 @@ import {
 import type { WalletProvider, MidnightProvider, UnboundTransaction } from '@midnight-ntwrk/midnight-js-types';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 
-import type { NetworkConfig } from './Config.js';
+import { DEFAULT_TX_TTL_MS, type NetworkConfig } from './Config.js';
 import { hexToBytes, bytesToHex } from './Utils.js';
 import { runEffect, runEffectPromise } from './Runtime.js';
 
@@ -353,7 +349,11 @@ export interface FromSeedOptions {
  *
  * @internal Effect source of truth
  */
-function providersEffect(walletContext: WalletContext): Effect.Effect<WalletProviders, WalletError> {
+function providersEffect(
+  walletContext: WalletContext,
+  options?: { txTtlMs?: number },
+): Effect.Effect<WalletProviders, WalletError> {
+  const defaultTtlMs = options?.txTtlMs ?? DEFAULT_TX_TTL_MS;
   return Effect.try({
     try: () => {
       const walletProvider: WalletProvider = {
@@ -362,7 +362,7 @@ function providersEffect(walletContext: WalletContext): Effect.Effect<WalletProv
         getEncryptionPublicKey: () =>
           walletContext.shieldedSecretKeys.encryptionPublicKey as unknown as ledger.EncPublicKey,
         balanceTx: async (tx: UnboundTransaction, ttl?: Date): Promise<ledger.FinalizedTransaction> => {
-          const txTtl = ttl ?? new Date(Date.now() + 30 * 60 * 1000);
+          const txTtl = ttl ?? new Date(Date.now() + defaultTtlMs);
           const recipe = await walletContext.wallet.balanceUnboundTransaction(
             tx,
             {
@@ -890,32 +890,6 @@ export function fromAddress(address: string): ReadonlyWallet {
 // =============================================================================
 
 /**
- * Initialize wallet from HD seed.
- *
- * @deprecated Use `Wallet.fromSeed(seed, networkConfig)` instead.
- * @throws {WalletError} When initialization fails
- *
- * @since 0.2.0
- * @category constructors
- */
-export async function init(seed: string, networkConfig: NetworkConfig): Promise<WalletContext> {
-  return runEffectPromise(initEffect(seed, networkConfig));
-}
-
-/**
- * Wait for wallet to sync with the network.
- *
- * @deprecated Use `Wallet.fromSeed(seed, networkConfig)` which syncs automatically.
- * @throws {WalletError} When sync fails
- *
- * @since 0.2.0
- * @category operations
- */
-export async function waitForSync(walletContext: WalletContext): Promise<void> {
-  return runEffectPromise(waitForSyncEffect(walletContext));
-}
-
-/**
  * Derive wallet address from seed without starting wallet connection.
  *
  * @throws {WalletError} When derivation fails
@@ -925,31 +899,6 @@ export async function waitForSync(walletContext: WalletContext): Promise<void> {
  */
 export function deriveAddress(seed: string, networkId: string): string {
   return runEffect(deriveAddressEffect(seed, networkId));
-}
-
-/**
- * Stop wallet sync and release WebSocket connections.
- *
- * @deprecated Use `wallet.close()` on the `ConnectedWallet` handle instead.
- * @throws {WalletError} When close fails
- *
- * @since 0.2.9
- * @category operations
- */
-export async function close(walletContext: WalletContext): Promise<void> {
-  return runEffectPromise(closeEffect(walletContext));
-}
-
-/**
- * Create WalletProvider and MidnightProvider from a seed wallet context.
- *
- * @deprecated Use `wallet.providers()` on the `ConnectedWallet` handle instead.
- *
- * @since 0.6.0
- * @category constructors
- */
-export function providers(walletContext: WalletContext): WalletProviders {
-  return runEffect(providersEffect(walletContext));
 }
 
 // =============================================================================
@@ -964,19 +913,6 @@ export function providers(walletContext: WalletContext): WalletProviders {
  */
 export function isWalletAvailable(): boolean {
   return runEffect(isAvailableEffect());
-}
-
-/**
- * Connect to the Lace wallet in browser.
- *
- * @deprecated Use `Wallet.fromBrowser(networkId)` instead.
- * @throws {WalletError} When connection fails
- *
- * @since 0.2.0
- * @category browser
- */
-export async function connectWallet(networkId: string = 'testnet'): Promise<WalletConnection> {
-  return runEffectPromise(connectEffect(networkId));
 }
 
 /**
@@ -995,21 +931,7 @@ export async function getWalletProvingProvider(
 }
 
 /**
- * Disconnect from the wallet (if supported).
- *
- * @deprecated Use `wallet.close()` on the `ConnectedWallet` handle instead.
- *
- * @since 0.2.0
- * @category browser
- */
-export async function disconnectWallet(): Promise<void> {
-  return runEffectPromise(disconnectEffect());
-}
-
-/**
  * Create providers from a connected wallet (v4 API).
- *
- * @deprecated Use `wallet.providers()` on the `ConnectedWallet` handle instead.
  *
  * @since 0.2.0
  * @category browser
@@ -1048,13 +970,13 @@ export const effect = {
   // Unified wallet factories
   fromSeed: fromSeedEffect,
   fromBrowser: fromBrowserEffect,
-  // Seed wallet (legacy — prefer fromSeed)
+  // Seed wallet lifecycle
   init: initEffect,
   waitForSync: waitForSyncEffect,
   deriveAddress: deriveAddressEffect,
   close: closeEffect,
   providers: providersEffect,
-  // Browser wallet connector (legacy — prefer fromBrowser)
+  // Browser wallet connector
   connect: connectEffect,
   isAvailable: isAvailableEffect,
   disconnect: disconnectEffect,

--- a/src/devnet/FeeRelay.ts
+++ b/src/devnet/FeeRelay.ts
@@ -24,7 +24,7 @@ import * as Rx from 'rxjs';
 import { Transaction, type FinalizedTransaction } from '@midnight-ntwrk/ledger-v7';
 import type { UnboundTransaction } from '@midnight-ntwrk/midnight-js-types';
 
-import type { NetworkConfig } from '../Config.js';
+import { DEFAULT_TX_TTL_MS, type NetworkConfig } from '../Config.js';
 import { hexToBytes, bytesToHex } from '../Utils.js';
 import * as Images from './Images.js';
 
@@ -116,6 +116,8 @@ async function createWallet(keys: DerivedKeys, networkConfig: NetworkConfig): Pr
 export interface ServerOptions {
   /** Port to listen on (default: 3002) */
   port?: number;
+  /** Transaction TTL in milliseconds (default: 30 minutes) */
+  txTtlMs?: number;
 }
 
 /**
@@ -149,7 +151,7 @@ export interface ServerOptions {
  * ```
  */
 export function startServer(networkConfig: NetworkConfig, options: ServerOptions = {}): Server {
-  const { port = 3002 } = options;
+  const { port = 3002, txTtlMs = DEFAULT_TX_TTL_MS } = options;
 
   // Genesis wallet — initialized lazily on first request, then kept alive
   let walletPromise: Promise<{ wallet: WalletFacade; keys: DerivedKeys }> | null = null;
@@ -210,7 +212,7 @@ export function startServer(networkConfig: NetworkConfig, options: ServerOptions
           ) as unknown as UnboundTransaction;
 
           // Balance and finalize using genesis wallet
-          const ttl = new Date(Date.now() + 30 * 60 * 1000);
+          const ttl = new Date(Date.now() + txTtlMs);
           const recipe = await wallet.balanceUnboundTransaction(
             unboundTx,
             {

--- a/test/e2e/contract.e2e.test.ts
+++ b/test/e2e/contract.e2e.test.ts
@@ -58,7 +58,7 @@ describe('Contract E2E Tests', () => {
 
   describe('Counter Contract Lifecycle', () => {
     let client: Midday.Client.MiddayClient;
-    let contract: Midday.Contract.DeployedContract;
+    let contract: Midday.Contract.DeployedContractFor<typeof CounterContract>;
     let contractAddress: string;
     let setupFailed = false;
 
@@ -113,11 +113,10 @@ describe('Contract E2E Tests', () => {
       expect(state).toBeDefined();
     });
 
-    it('should call increment() again and verify state increased', { timeout: 120_000 }, async () => {
+    it('should increment again and verify state increased', { timeout: 120_000 }, async () => {
       if (setupFailed) return;
 
-      // Untyped fallback still works
-      const result = await contract.call('increment');
+      const result = await contract.actions.increment();
 
       expect(result).toBeDefined();
       expect(result.txHash).toBeDefined();
@@ -193,7 +192,7 @@ describe('Contract E2E Tests', () => {
         const deployed = await userContract.join(contractAddress);
 
         // THE TEST: user wallet calls increment, genesis pays the fee
-        const result = await deployed.call('increment');
+        const result = await deployed.actions.increment();
 
         expect(result.txHash).toBeDefined();
         expect(result.blockHeight).toBeGreaterThan(0);

--- a/test/e2e/witness-contract.e2e.test.ts
+++ b/test/e2e/witness-contract.e2e.test.ts
@@ -197,7 +197,7 @@ describe('Witness Contract E2E Tests', () => {
         expect(contract.address).toBeDefined();
 
         // Initialize
-        await contract.call('init', PASSWORD_HASH);
+        await contract.actions.init(PASSWORD_HASH);
 
         const attackerLoaded = await wrongClient.loadContract({
           module: SecretCounterContract,
@@ -211,7 +211,7 @@ describe('Witness Contract E2E Tests', () => {
 
         // Should fail because password doesn't match
         await expect(
-          joinedContract.call('increment', 1n)
+          joinedContract.actions.increment(1n)
         ).rejects.toThrow('invalid password');
       } finally {
         await correctClient.close();


### PR DESCRIPTION
## Summary

Major simplification of the Client module and API surface. Removes dead code, eliminates indirection, extracts shared logic, and improves type ergonomics.

**Net result: −717 lines removed, +573 added (−144 LOC)**. All 22 tests pass.

---

## Breaking Changes

| Removed | Replacement |
|---------|-------------|
| `ClientService`, `ClientServiceImpl`, `ClientLive` | Use `MiddayClientService` + `layer()` / `layerFromWallet()` |
| `services()` | Unused — delete call sites |
| `MiddayClient.wallet` / `MiddayClient.relayerWallet` | Internal detail, no longer exposed |
| `ClientData` (internal) | Functions return `MiddayClient` directly |
| `ContractState`, `Contract` (union type), `ContractData`, `createContractHandle` | Use `LoadedContract` / `DeployedContract` |
| `Wallet.init()`, `waitForSync()`, `close()`, `providers()` | Use `Wallet.fromSeed()` or `wallet.close()` on the handle |
| `Wallet.connectWallet()`, `disconnectWallet()` | Use `Wallet.fromBrowser()` / `wallet.close()` |
| `layerFromWallet` config no longer accepts `zkConfigProvider` | Removed — was unused |

## New

- **`FeeRelay` module** (`src/FeeRelay.ts`) — extracts seed-based and HTTP-based relay logic from Client (~163 LOC, single responsibility)
- **`DeployedContractFor<M>`** / **`LoadedContractFor<M>`** — convenience type aliases so you write `DeployedContractFor<typeof CounterContract>` instead of `DeployedContract<InferLedger<M>, InferCircuits<M>, InferActions<M>>`
- **`FromWalletConfig`** — dedicated config interface for `Client.fromWallet()`
- **`effect.fromWalletScoped`** — scoped variant for browser wallet connections
- **Configurable `txTtlMs`** on `ClientConfig`, `FromWalletConfig`, and fee relay options (default: `Config.DEFAULT_TX_TTL_MS` = 30 min)

## Improvements

- **No more `ClientData` indirection** — `createEffect` and `fromWalletEffect` return `MiddayClient` directly via `buildClient()`
- **Scoped variants reuse the Effect path** — `createScoped` / `fromWalletScoped` are just `acquireRelease(createEffect(...), close)`, no duplicated logic
- **`Effect.orDie`** in acquireRelease release functions — close failures are visible defects, not silently swallowed
- **`layerFromWallet`** reuses `effect.fromWalletScoped` instead of duplicating the pipeline
- **`import * as Module`** pattern for all internal modules (Effect style) with qualified type access
- **All tests and JSDoc** updated to use typed `contract.actions.*()` instead of untyped `contract.call()`

## Tests

All 22 tests pass (3 test files):
- `devnet.integration.test.ts` — 12 tests
- `contract.e2e.test.ts` — 6 tests (including fee relay)
- `witness-contract.e2e.test.ts` — 4 tests
