### PR TITLE
fix: match scoped package tags in post-release-to-x workflow

### DIFF
--- a/.github/workflows/post-release-to-x.yml
+++ b/.github/workflows/post-release-to-x.yml
@@ -19,7 +19,7 @@ jobs:
         id: release
         run: |
           # Get the latest release with actual changes (not just dependency updates)
-          RELEASES=$(gh api /repos/${{ github.repository }}/releases --jq '[.[] | select(.tag_name | startswith("v"))]')
+          RELEASES=$(gh api /repos/${{ github.repository }}/releases --jq '[.[] | select(.tag_name | startswith("@no-witness-labs/midday-sdk@"))]')
 
           TAG=""
           URL=""
@@ -48,8 +48,9 @@ jobs:
               if [ -n "$REAL_CHANGES" ]; then
                 TAG=$RELEASE_TAG
                 URL=$RELEASE_URL
-                # Extract version number (remove 'v' prefix)
-                echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+                # Extract version number (remove scoped package prefix)
+                VERSION=${TAG##*@}
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
                 break
               fi
             fi
@@ -116,7 +117,7 @@ jobs:
             (async () => {
               const mediaId = await client.v1.uploadMedia('./release-snippet.png');
               await client.v2.tweet({
-                text: 'Midday SDK ${{ steps.release.outputs.tag }} out now\n${{ steps.release.outputs.url }}\nHappy building!',
+                text: 'Midday SDK v${{ steps.release.outputs.version }} out now\n${{ steps.release.outputs.url }}\nHappy building!',
                 media: { media_ids: [mediaId] }
               });
             })()
@@ -146,7 +147,7 @@ jobs:
             });
             (async () => {
               await client.v2.tweet({
-                text: 'Midday SDK ${{ steps.release.outputs.tag }} out now\n${{ steps.release.outputs.url }}\nHappy building!'
+                text: 'Midday SDK v${{ steps.release.outputs.version }} out now\n${{ steps.release.outputs.url }}\nHappy building!'
               });
             })()
               .then(() => process.exit(0))


### PR DESCRIPTION
## Problem

The "Post Release to X" workflow completed successfully but never actually posted — all steps were silently skipped.

### Root cause

The jq filter used `startswith("v")` to find releases, but all release tags are scoped package names like `@no-witness-labs/midday-sdk@0.3.0`. The filter returned an empty array, so `found=false` and every conditional step was skipped.

### Fixes

1. **Tag filter**: `startswith("v")` → `startswith("@no-witness-labs/midday-sdk@")`
2. **Version extraction**: `${TAG#v}` → `${TAG##*@}` to strip the full scoped prefix and get `0.3.0`
3. **Tweet text**: Uses `v0.3.0` format instead of the raw tag name