### PR TITLE
feat: add preprod network support

### DIFF
--- a/examples/browser-lace/index.html
+++ b/examples/browser-lace/index.html
@@ -127,6 +127,7 @@
       <select id="network-select" style="padding: 0.5rem; margin-right: 0.5rem; border-radius: 6px; border: 1px solid #d1d5db;">
         <option value="undeployed">Local Devnet</option>
         <option value="preview">Preview (Testnet)</option>
+        <option value="preprod">Preprod (Testnet)</option>
       </select>
       <button id="connect-btn">Connect Wallet</button>
       <label id="fee-relay-toggle" style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.75rem; font-size: 0.875rem; color: #374151; cursor: pointer;">

--- a/examples/browser-lace/src/main.ts
+++ b/examples/browser-lace/src/main.ts
@@ -48,7 +48,7 @@ async function connectWallet() {
 
     // Connect to wallet - this will prompt user to approve
     const network = networkSelect?.value || 'undeployed';
-    wallet = await Midday.Wallet.fromBrowser(network as 'preview' | 'undeployed');
+    wallet = await Midday.Wallet.fromBrowser(network);
 
     updateStatus('Creating SDK client...');
 
@@ -264,6 +264,16 @@ connectBtn.addEventListener('click', connectWallet);
 (window as unknown as { readState: typeof readState }).readState = readState;
 (window as unknown as { refreshBalance: typeof refreshBalance }).refreshBalance = refreshBalance;
 (window as unknown as { fundWallet: typeof fundWallet }).fundWallet = fundWallet;
+
+// Auto-disable fee relay for non-local networks
+networkSelect.addEventListener('change', () => {
+  const feeRelayCheckbox = document.getElementById('fee-relay-checkbox') as HTMLInputElement;
+  const isLocal = networkSelect.value === 'undeployed';
+  feeRelayCheckbox.checked = isLocal;
+  feeRelayCheckbox.disabled = !isLocal;
+  const label = document.getElementById('fee-relay-toggle') as HTMLLabelElement;
+  if (label) label.style.opacity = isLocal ? '1' : '0.5';
+});
 
 // Initial status
 updateStatus('Select network and click "Connect Wallet" to begin');

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -35,6 +35,13 @@ export const NETWORKS: Record<string, NetworkConfig> = {
     node: 'wss://rpc.preview.midnight.network',
     proofServer: 'http://localhost:6300',
   },
+  preprod: {
+    networkId: 'preprod',
+    indexer: 'https://indexer.preprod.midnight.network/api/v3/graphql',
+    indexerWS: 'wss://indexer.preprod.midnight.network/api/v3/graphql/ws',
+    node: 'wss://rpc.preprod.midnight.network',
+    proofServer: 'http://localhost:6300',
+  },
 } as const;
 
 /**
@@ -43,7 +50,7 @@ export const NETWORKS: Record<string, NetworkConfig> = {
  * Note: Environment variable overrides have been removed for browser compatibility.
  * Use explicit configuration via Client.create() options instead.
  *
- * @param network - Network name ('local' or 'preview')
+ * @param network - Network name ('local', 'preview', or 'preprod')
  * @returns Network configuration
  */
 export function getNetworkConfig(network: string = 'local'): NetworkConfig {


### PR DESCRIPTION
- Add preprod network config to \`Config.ts\` (indexer, WS, node, proofServer URLs)
- Add preprod option to browser-lace network dropdown
- Auto-disable fee relay checkbox when selecting non-local networks
- Remove unnecessary type narrowing on \`fromBrowser\` network param