### PR TITLE
chore(wallet): drop signTransactionIntents workaround for upstream signRecipe

### DIFF
--- a/.changeset/drop-sign-intents-workaround.md
+++ b/.changeset/drop-sign-intents-workaround.md
@@ -1,0 +1,9 @@
+---
+"@no-witness-labs/midday-sdk": patch
+---
+
+Remove `signTransactionIntents` workaround in favor of upstream `WalletFacade.signRecipe`.
+
+The workaround predated `wallet-sdk-unshielded-wallet@1.0.0`, where `addSignature` hard-coded the `'pre-proof'` proof marker even when cloning intents that already carried `'proof'` after balancing — causing `Failed to clone intent` at finalize time. `wallet-sdk-facade@4.0.0` (in the 2026-04-23 release batch) fixes this by routing the proven base transaction through `signUnboundTransaction` and the unproven balancer through `signUnprovenTransaction`, each with the correct marker. `signRecipe` now produces the same output as the manual hand-rolled path.
+
+Internal-only cleanup. No public API change. Validated against the contract and witness-contract E2E suites (9/9 passing) covering deploy + circuit-call flows.

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -436,65 +436,8 @@ export interface FromSeedOptions {
   sync?: boolean;
 }
 
-// =============================================================================
-// Internal — Intent Signing Workaround
-// =============================================================================
-
 /**
- * Workaround for wallet-sdk-unshielded-wallet v1.0.0 bug.
- *
- * `TransactionOps.addSignature()` hard-codes `'pre-proof'` when cloning intents,
- * but after proving the base transaction, intents carry `'proof'`. The WASM
- * deserializer fails with "Failed to clone intent".
- *
- * This helper manually signs intents with the correct proof marker and writes
- * them back, bypassing the buggy `signRecipe` path inside `finalizeRecipe`.
- *
- * @see https://github.com/midnightntwrk/example-counter/blob/main/MIGRATION_GUIDE.md
- * @internal
- */
-export function signTransactionIntents(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tx: { intents?: Map<number, any> },
-  signFn: (payload: Uint8Array) => ledger.Signature,
-  proofMarker: 'proof' | 'pre-proof',
-): void {
-  if (!tx.intents || tx.intents.size === 0) return;
-
-  for (const segment of tx.intents.keys()) {
-    const intent = tx.intents.get(segment);
-    if (!intent) continue;
-
-    const cloned = ledger.Intent.deserialize(
-      'signature' as ledger.SignatureEnabled['instance'],
-      proofMarker as ledger.Proof['instance'],
-      'pre-binding' as ledger.PreBinding['instance'],
-      intent.serialize(),
-    );
-
-    const sigData = cloned.signatureData(segment);
-    const signature = signFn(sigData);
-
-    if (cloned.fallibleUnshieldedOffer) {
-      const sigs = cloned.fallibleUnshieldedOffer.inputs.map(
-        (_: unknown, i: number) => cloned.fallibleUnshieldedOffer!.signatures.at(i) ?? signature,
-      );
-      cloned.fallibleUnshieldedOffer = cloned.fallibleUnshieldedOffer.addSignatures(sigs);
-    }
-
-    if (cloned.guaranteedUnshieldedOffer) {
-      const sigs = cloned.guaranteedUnshieldedOffer.inputs.map(
-        (_: unknown, i: number) => cloned.guaranteedUnshieldedOffer!.signatures.at(i) ?? signature,
-      );
-      cloned.guaranteedUnshieldedOffer = cloned.guaranteedUnshieldedOffer.addSignatures(sigs);
-    }
-
-    tx.intents.set(segment, cloned);
-  }
-}
-
-/**
- * Balance, sign (with workaround), and finalize a transaction using a seed wallet.
+ * Balance, sign, and finalize a transaction using a seed wallet.
  *
  * @internal
  */
@@ -512,13 +455,11 @@ export async function balanceAndFinalize(
     { ttl },
   );
 
-  const signFn = (payload: Uint8Array) => walletContext.unshieldedKeystore.signData(payload);
-  signTransactionIntents(recipe.baseTransaction, signFn, 'proof');
-  if (recipe.balancingTransaction) {
-    signTransactionIntents(recipe.balancingTransaction, signFn, 'pre-proof');
-  }
+  const signedRecipe = await walletContext.wallet.signRecipe(recipe, (payload: Uint8Array) =>
+    walletContext.unshieldedKeystore.signData(payload),
+  );
 
-  return walletContext.wallet.finalizeRecipe(recipe);
+  return walletContext.wallet.finalizeRecipe(signedRecipe);
 }
 
 // =============================================================================

--- a/src/devnet/FeeRelay.ts
+++ b/src/devnet/FeeRelay.ts
@@ -25,7 +25,6 @@ import type { UnboundTransaction } from '@midnight-ntwrk/midnight-js-types';
 
 import { DEFAULT_TX_TTL_MS, type NetworkConfig } from '../Config.js';
 import { hexToBytes, bytesToHex } from '../Utils.js';
-import { signTransactionIntents } from '../Wallet.js';
 import * as Images from './Images.js';
 
 /**
@@ -230,15 +229,11 @@ export function startServer(networkConfig: NetworkConfig, options: ServerOptions
             { ttl },
           );
 
-          // Workaround: wallet-sdk-unshielded-wallet v1.0.0 bug —
-          // signRecipe uses 'pre-proof' but proven intents need 'proof'
-          const signFn = (payload: Uint8Array) => keys.unshieldedKeystore.signData(payload);
-          signTransactionIntents(recipe.baseTransaction, signFn, 'proof');
-          if (recipe.balancingTransaction) {
-            signTransactionIntents(recipe.balancingTransaction, signFn, 'pre-proof');
-          }
+          const signedRecipe = await wallet.signRecipe(recipe, (payload: Uint8Array) =>
+            keys.unshieldedKeystore.signData(payload),
+          );
 
-          const finalized = await wallet.finalizeRecipe(recipe);
+          const finalized = await wallet.finalizeRecipe(signedRecipe);
 
           // Serialize back to hex
           const finalizedBytes = finalized.serialize();
@@ -291,11 +286,11 @@ export function startServer(networkConfig: NetworkConfig, options: ServerOptions
             { ttl, tokenKindsToBalance: ['dust'] },
           );
 
-          // Sign relay's balancing transaction intents (originalTransaction is already finalized)
-          const signFn = (payload: Uint8Array) => keys.unshieldedKeystore.signData(payload);
-          signTransactionIntents(recipe.balancingTransaction, signFn, 'pre-proof');
+          const signedRecipe = await wallet.signRecipe(recipe, (payload: Uint8Array) =>
+            keys.unshieldedKeystore.signData(payload),
+          );
 
-          const finalized = await wallet.finalizeRecipe(recipe);
+          const finalized = await wallet.finalizeRecipe(signedRecipe);
 
           // Serialize back to hex
           const finalizedBytes = finalized.serialize();


### PR DESCRIPTION
## Summary

Removes the `signTransactionIntents` helper (and the manual intent-cloning logic) in favor of the upstream `WalletFacade.signRecipe`, which became correct in `wallet-sdk-facade@4.0.0` (the 2026-04-23 release batch we adopted in #100).

**Why now**: the workaround was added against `wallet-sdk-unshielded-wallet@1.0.0`'s `addSignature` bug, which hard-coded the `'pre-proof'` marker when cloning intents — failing on proven base transactions whose intents already carry `'proof'`. `wallet-sdk-facade@4.0.0` fixes this by routing the recipe through `signUnboundTransaction` (proven base, `'proof'`) and `signUnprovenTransaction` (unproven balancer, `'pre-proof'`) separately.

## Changes

- `src/Wallet.ts` — replace `signTransactionIntents` calls in `balanceAndFinalize` with `wallet.signRecipe`. Delete the helper and its workaround comments. **−65 lines, +9 lines net**.
- `src/devnet/FeeRelay.ts` — same treatment at both the `/balance-tx` and `/balance-finalized-tx` endpoints.
- `src/devnet/Faucet.ts` — already used `signRecipe`; no change needed.

## Validation

- ✅ `pnpm type-check` clean
- ✅ `pnpm build` clean
- ✅ E2E: `test/e2e/contract.e2e.test.ts` — 5/5 (deploy + 3 circuit calls + join)
- ✅ E2E: `test/e2e/witness-contract.e2e.test.ts` — 4/4 (deploy + 3 circuit calls with private witness)

Both suites exercise the full `balanceUnboundTransaction → signRecipe → finalizeRecipe → submit` flow against a local devnet. **9/9 green.**

## Risk

Low. Internal-only refactor; no public API change. If `signRecipe` produced functionally different output, contract submission would fail loudly — and it doesn't.

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm build`
- [x] `DOCKER_HOST=unix:///var/run/docker.sock pnpm vitest run test/e2e/contract.e2e.test.ts`
- [x] `DOCKER_HOST=unix:///var/run/docker.sock pnpm vitest run test/e2e/witness-contract.e2e.test.ts`