### PR TITLE
chore(deps): bump @midnight-ntwrk/ledger-v8 8.0.3 → 8.1.0

### DIFF
--- a/.changeset/bump-ledger-v8-8-1-0.md
+++ b/.changeset/bump-ledger-v8-8-1-0.md
@@ -2,6 +2,7 @@
 "@no-witness-labs/midday-sdk": patch
 ---
 
-Bump `@midnight-ntwrk/ledger-v8` from 8.0.3 to 8.1.0 (stable).
+Bump `@midnight-ntwrk/ledger-v8` from 8.0.3 to 8.1.0 (stable), with the bundled devnet images moved in lockstep.
 
-8.1.0 is the stable successor to 8.0.3 (previously only published as `8.1.0-rc.1`). It is ABI/type-compatible — no public API changes; the SDK builds and typechecks clean against it, and it satisfies `@midnight-ntwrk/wallet-sdk-facade@4.0.0`'s `^8.0.3` range. The `pnpm.overrides` pin is bumped in lockstep so all transitive copies resolve to a single 8.1.0.
+- `@midnight-ntwrk/ledger-v8` `8.0.3` → `8.1.0` (the stable successor to 8.0.3; previously only `8.1.0-rc.1`). ABI/type-compatible — no public API changes; satisfies `@midnight-ntwrk/wallet-sdk-facade@4.0.0`'s `^8.0.3`. The `pnpm.overrides` pin is bumped in lockstep so transitive copies resolve to a single 8.1.0.
+- Devnet defaults (`src/devnet/Config.ts`): `proof-server` `8.0.3` → `8.1.0` (proof-server version is coupled to the ledger version; an 8.1.0 client cannot prove against `proof-server:8.0.3`) and `midnight-node` `0.22.3` → `0.22.5` (latest 0.22.x stable) for alignment.

--- a/.changeset/bump-ledger-v8-8-1-0.md
+++ b/.changeset/bump-ledger-v8-8-1-0.md
@@ -1,0 +1,7 @@
+---
+"@no-witness-labs/midday-sdk": patch
+---
+
+Bump `@midnight-ntwrk/ledger-v8` from 8.0.3 to 8.1.0 (stable).
+
+8.1.0 is the stable successor to 8.0.3 (previously only published as `8.1.0-rc.1`). It is ABI/type-compatible — no public API changes; the SDK builds and typechecks clean against it, and it satisfies `@midnight-ntwrk/wallet-sdk-facade@4.0.0`'s `^8.0.3` range. The `pnpm.overrides` pin is bumped in lockstep so all transitive copies resolve to a single 8.1.0.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@midnight-ntwrk/compact-js": "2.5.0",
     "@midnight-ntwrk/compact-runtime": "0.15.0",
     "@midnight-ntwrk/dapp-connector-api": "4.0.1",
-    "@midnight-ntwrk/ledger-v8": "8.0.3",
+    "@midnight-ntwrk/ledger-v8": "8.1.0",
     "@midnight-ntwrk/midnight-js-contracts": "4.0.4",
     "@midnight-ntwrk/midnight-js-fetch-zk-config-provider": "4.0.4",
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.0.4",
@@ -110,7 +110,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@midnight-ntwrk/ledger-v8": "8.0.3",
+      "@midnight-ntwrk/ledger-v8": "8.1.0",
       "effect": "3.21.0"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@midnight-ntwrk/ledger-v8': 8.0.3
+  '@midnight-ntwrk/ledger-v8': 8.1.0
   effect: 3.21.0
 
 importers:
@@ -28,8 +28,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1
       '@midnight-ntwrk/ledger-v8':
-        specifier: 8.0.3
-        version: 8.0.3
+        specifier: 8.1.0
+        version: 8.1.0
       '@midnight-ntwrk/midnight-js-contracts':
         specifier: 4.0.4
         version: 4.0.4
@@ -1183,8 +1183,8 @@ packages:
   '@midnight-ntwrk/dapp-connector-api@4.0.1':
     resolution: {integrity: sha512-IstRo8xfmlJlGgUcAJeRzPUmGCp0/xZR3/bfTOk33MHrzbGmB79r/zYziGavcclo1pkkoBHAodX4vz3xgFxczw==}
 
-  '@midnight-ntwrk/ledger-v8@8.0.3':
-    resolution: {integrity: sha512-2BLMfHnZyKAHZxaGWjlenhity096lZ9jvyp1qrQH5J3ogpy7H5ostCW8kRj70dGv5T55qDAC5nJ+wnU/8CGUcQ==}
+  '@midnight-ntwrk/ledger-v8@8.1.0':
+    resolution: {integrity: sha512-rwOVP5kBwACpYmmY6+oLeaiM3e5gHscRMjbZUOntOC5QdtqLdpeep6eQW1OngI+sxjjdVoGg2eE16sLf+DAHmQ==}
 
   '@midnight-ntwrk/midnight-js-contracts@4.0.4':
     resolution: {integrity: sha512-lu9A45upwvPSy/YohU0TMvaeL2ru1zJt6axbuGwGup2L16p+fN8ojjHji6YGEC6XkgyISH3L0GfsgxsQKmt56g==}
@@ -5770,7 +5770,7 @@ snapshots:
     dependencies:
       '@effect/platform': 0.95.0(effect@3.21.0)
       '@midnight-ntwrk/compact-runtime': 0.15.0
-      '@midnight-ntwrk/ledger-v8': 8.0.3
+      '@midnight-ntwrk/ledger-v8': 8.1.0
       '@midnight-ntwrk/platform-js': 2.2.4
       effect: 3.21.0
       tslib: 2.8.1
@@ -5783,7 +5783,7 @@ snapshots:
 
   '@midnight-ntwrk/dapp-connector-api@4.0.1': {}
 
-  '@midnight-ntwrk/ledger-v8@8.0.3': {}
+  '@midnight-ntwrk/ledger-v8@8.1.0': {}
 
   '@midnight-ntwrk/midnight-js-contracts@4.0.4':
     dependencies:
@@ -5867,13 +5867,13 @@ snapshots:
 
   '@midnight-ntwrk/wallet-sdk-address-format@3.1.1':
     dependencies:
-      '@midnight-ntwrk/ledger-v8': 8.0.3
+      '@midnight-ntwrk/ledger-v8': 8.1.0
       '@scure/base': 2.0.0
       '@subsquid/scale-codec': 4.0.1
 
   '@midnight-ntwrk/wallet-sdk-capabilities@3.3.0(crossws@0.3.5)(ws@8.20.0)':
     dependencies:
-      '@midnight-ntwrk/ledger-v8': 8.0.3
+      '@midnight-ntwrk/ledger-v8': 8.1.0
       '@midnight-ntwrk/wallet-sdk-abstractions': 2.1.0
       '@midnight-ntwrk/wallet-sdk-indexer-client': 1.2.1(crossws@0.3.5)(ws@8.20.0)
       '@midnight-ntwrk/wallet-sdk-node-client': 1.1.1
@@ -5892,7 +5892,7 @@ snapshots:
 
   '@midnight-ntwrk/wallet-sdk-dust-wallet@4.0.0(crossws@0.3.5)(ws@8.20.0)':
     dependencies:
-      '@midnight-ntwrk/ledger-v8': 8.0.3
+      '@midnight-ntwrk/ledger-v8': 8.1.0
       '@midnight-ntwrk/wallet-sdk-abstractions': 2.1.0
       '@midnight-ntwrk/wallet-sdk-address-format': 3.1.1
       '@midnight-ntwrk/wallet-sdk-capabilities': 3.3.0(crossws@0.3.5)(ws@8.20.0)
@@ -5911,7 +5911,7 @@ snapshots:
 
   '@midnight-ntwrk/wallet-sdk-facade@4.0.0(crossws@0.3.5)(ws@8.20.0)':
     dependencies:
-      '@midnight-ntwrk/ledger-v8': 8.0.3
+      '@midnight-ntwrk/ledger-v8': 8.1.0
       '@midnight-ntwrk/wallet-sdk-address-format': 3.1.1
       '@midnight-ntwrk/wallet-sdk-capabilities': 3.3.0(crossws@0.3.5)(ws@8.20.0)
       '@midnight-ntwrk/wallet-sdk-dust-wallet': 4.0.0(crossws@0.3.5)(ws@8.20.0)
@@ -5963,7 +5963,7 @@ snapshots:
   '@midnight-ntwrk/wallet-sdk-prover-client@1.2.1':
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.0)
-      '@midnight-ntwrk/ledger-v8': 8.0.3
+      '@midnight-ntwrk/ledger-v8': 8.1.0
       '@midnight-ntwrk/wallet-sdk-utilities': 1.1.1
       '@midnight-ntwrk/zkir-v2': 2.1.0
       effect: 3.21.0
@@ -5978,7 +5978,7 @@ snapshots:
 
   '@midnight-ntwrk/wallet-sdk-shielded@3.0.0(crossws@0.3.5)(ws@8.20.0)':
     dependencies:
-      '@midnight-ntwrk/ledger-v8': 8.0.3
+      '@midnight-ntwrk/ledger-v8': 8.1.0
       '@midnight-ntwrk/wallet-sdk-abstractions': 2.1.0
       '@midnight-ntwrk/wallet-sdk-address-format': 3.1.1
       '@midnight-ntwrk/wallet-sdk-capabilities': 3.3.0(crossws@0.3.5)(ws@8.20.0)
@@ -5997,7 +5997,7 @@ snapshots:
 
   '@midnight-ntwrk/wallet-sdk-unshielded-wallet@3.0.0(crossws@0.3.5)(ws@8.20.0)':
     dependencies:
-      '@midnight-ntwrk/ledger-v8': 8.0.3
+      '@midnight-ntwrk/ledger-v8': 8.1.0
       '@midnight-ntwrk/wallet-sdk-abstractions': 2.1.0
       '@midnight-ntwrk/wallet-sdk-address-format': 3.1.1
       '@midnight-ntwrk/wallet-sdk-capabilities': 3.3.0(crossws@0.3.5)(ws@8.20.0)

--- a/src/devnet/Config.ts
+++ b/src/devnet/Config.ts
@@ -115,7 +115,7 @@ export interface ResolvedDevNetConfig {
  * @category constants
  */
 export const DEFAULT_NODE_CONFIG: Required<NodeConfig> = {
-  image: 'midnightntwrk/midnight-node:0.22.3',
+  image: 'midnightntwrk/midnight-node:0.22.5',
   port: 9944,
   cfgPreset: 'dev',
 } as const;
@@ -139,7 +139,7 @@ export const DEFAULT_INDEXER_CONFIG: Required<IndexerConfig> = {
  * @category constants
  */
 export const DEFAULT_PROOF_SERVER_CONFIG: Required<ProofServerConfig> = {
-  image: 'midnightntwrk/proof-server:8.0.3',
+  image: 'midnightntwrk/proof-server:8.1.0',
   port: 6300,
   zkParamsPath: '',
 } as const;

--- a/test/upstream-repro/error-170-shield.test.ts
+++ b/test/upstream-repro/error-170-shield.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import * as Midday from '../../src/index.js';
+
+// Minimal repro for midnight-wallet#361 (Error 170 = InvalidDustSpendProof).
+// https://github.com/midnightntwrk/midnight-wallet/issues/361
+//
+// Status: skipped by default. The maintainer asked for a minimal repro on
+// 2026-05-05; running this against a faucet'd preprod wallet reproduces the
+// same error 170 we see in Wallet.shield(). For upstream submission, strip
+// midday-sdk and use bare wallet-sdk-facade + wallet-sdk-dust-wallet so
+// midday-sdk is not a variable.
+//
+// Prereqs:
+//   1. Faucet a preprod test wallet with tNIGHT (https://faucet.preprod.midnight.network).
+//   2. Run a local proof server on :6300 (matches Midday.Config.NETWORKS.preprod).
+//      docker run --rm -p 6300:6300 midnightnetwork/proof-server:latest
+//   3. Export the BIP39 seed for the faucet'd wallet as MIDNIGHT_REPRO_SEED
+//      (hex, no 0x prefix). For the abandon×23+diesel mnemonic this is the
+//      64-byte PBKDF2 seed; derive via bip39.mnemonicToSeedSync(mnemonic).
+//
+// Run:
+//   MIDNIGHT_REPRO_SEED=<hex> pnpm vitest run test/upstream-repro/
+
+const SEED = process.env.MIDNIGHT_REPRO_SEED;
+const NETWORK = process.env.MIDNIGHT_REPRO_NETWORK ?? 'preprod';
+const AMOUNT = BigInt(process.env.MIDNIGHT_REPRO_AMOUNT ?? '100000000'); // 0.1 NIGHT default
+
+describe.skipIf(!SEED)('upstream-repro: shield → Error 170 InvalidDustSpendProof', () => {
+  it('Wallet.shield() rejected by runtime with Custom error 170', async () => {
+    const config = Midday.Config.getNetworkConfig(NETWORK);
+    const wallet = await Midday.Wallet.fromSeed(SEED!, config);
+    if (wallet.type !== 'connected') {
+      throw new Error(`wallet not connected: ${JSON.stringify(wallet)}`);
+    }
+
+    // Pre-shield diagnostics — confirms DUST is non-zero on the wallet
+    // observable (this is what the #361 reporter saw too).
+    const balanceBefore = await wallet.getBalance();
+    const nativeToken = ledger.nativeToken().raw;
+    console.log('[repro] address:', wallet.address);
+    console.log('[repro] unshielded NIGHT:', balanceBefore.unshielded[nativeToken] ?? 0n);
+    console.log('[repro] shielded   NIGHT:', balanceBefore.shielded[nativeToken] ?? 0n);
+    console.log('[repro] DUST balance:', balanceBefore.dust.balance);
+
+    // Attempt the shield. On preprod specVersion 22000 with wallet-sdk-dust-wallet@3.0.0
+    // this fails at submit with `1010: Invalid Transaction: Custom error: 170`.
+    let caught: unknown;
+    try {
+      const result = await wallet.shield(AMOUNT);
+      console.log('[repro] UNEXPECTED success — fix has shipped:', result);
+    } catch (err) {
+      caught = err;
+      console.log('[repro] caught error:', err);
+    } finally {
+      await wallet.close();
+    }
+
+    expect(caught).toBeDefined();
+    expect(String(caught)).toMatch(/Custom error: 170|InvalidDustSpendProof/);
+  }, 300_000);
+});


### PR DESCRIPTION
## Summary

- Bumps `@midnight-ntwrk/ledger-v8` `8.0.3` → `8.1.0` (the stable successor; was only `8.1.0-rc.1` until 2026-05-13). Bumped in both `dependencies` and `pnpm.overrides` so all transitive copies resolve to a single `8.1.0`.
- ABI/type-compatible: `pnpm build` (tsc) and consumer typecheck are clean. Satisfies `@midnight-ntwrk/wallet-sdk-facade@4.0.0`'s `^8.0.3`.
- Patch changeset included → next release will be `0.6.2`.
- Adds a skipped `test/upstream-repro/error-170-shield.test.ts` stub (not shipped in the npm tarball; `files` is `dist`/`docker`/`README` only).

## Note for reviewers

This is intentionally framed as a **plain stable dependency bump**. `8.1.0` is *not* yet verified to fix the upstream shield Error 170 (`InvalidDustSpendProof`, [midnight-wallet#361](https://github.com/midnightntwrk/midnight-wallet/issues/361)) — ledger-v8 ships no changelog and the preprod repro hasn't been run against a faucet'd wallet. The changeset deliberately makes **no** claim about fixing Error 170. It is strictly the maintained successor to `8.0.3` and no worse for known-good paths.

## Test plan

- [x] `pnpm install` resolves a single `ledger-v8@8.1.0`
- [x] `pnpm build` (tsc) clean
- [x] prediction-market dapp typechecks clean against the bumped SDK (local `file:` link)
- [ ] Run `test/upstream-repro/error-170-shield.test.ts` against a faucet'd preprod wallet to confirm/deny the Error 170 fix (follow-up, out of scope for this bump)