### PR TITLE
refactor(errors): finer-grained TaggedErrors in Wallet/Contract/ZkConfig

### DIFF
--- a/.changeset/wallet-finer-grained-errors.md
+++ b/.changeset/wallet-finer-grained-errors.md
@@ -1,0 +1,27 @@
+---
+"@no-witness-labs/midday-sdk": patch
+---
+
+Add finer-grained `Data.TaggedError` subtypes across `Wallet`, `Contract`, and `ZkConfig`, replacing 14 raw `throw new Error(...)` calls that previously collapsed into a single catch-all `*Error.cause` string.
+
+**New error classes (all `Data.TaggedError`):**
+
+`Wallet`:
+- **`WalletKeyDerivationError`** — `HDWallet.fromSeed` / `deriveKeysAt` failure. Field `phase: 'init' | 'derive'`.
+- **`LaceUnavailableError`** — Lace extension missing or too old. Field `reason: 'not-installed' | 'incompatible-version'`.
+- **`LaceTransferError`** — `balanceUnsealedTransaction` rejected by Lace. Field `operation: 'balance'`, `detail` carries joined `APIError` fields.
+- **`TransactionDeserializeError`** — `ledger.Transaction.deserialize` failed on Lace-returned bytes (typically version skew). Field `bytesLength`.
+- **`DustRegistrationError`** — no eligible NIGHT UTXOs to (de)register for DUST generation. Field `direction`, `reason: 'no-eligible-utxos'`.
+
+`Contract`:
+- **`ContractStateNotFoundError`** — `queryContractState` returned no result. Field `address`, optional `blockHeight`. Surfaces from `getState`/`getStateAt`/`ledgerState`/`ledgerStateAt` and the `Readonly` `readState`/`readStateAt`/`readRawState`/`readRawStateAt` variants. Distinct from `ContractError` because consumers may want "not yet deployed → redirect to create flow" UX.
+- **`ContractLoadArgsError`** — `loadContract` called without one of the required argument shapes (`module` + `zkConfig`, `path`, or `moduleUrl` + `zkConfigBaseUrl`).
+
+`ZkConfig`:
+- **`ZkConfigFetchError`** — HTTP fetch for a ZK key returned a non-ok response. Fields `url`, `status`, `statusText`.
+
+`WalletError`, `ContractError`, and `ZkConfigError` are **unchanged** and remain the catch-all for genuinely-unclassified upstream failures. Effect signatures on affected paths widen to union types (e.g., `Effect.Effect<ShieldResult, WalletError | LaceUnavailableError>`, `Effect.Effect<unknown, ContractError | ContractStateNotFoundError>`, `Effect.Effect<ZKIR, ZkConfigError | ZkConfigFetchError>`). Additive at the type level:
+
+- Effect consumers using `catchAll` or no explicit error annotation are unaffected.
+- Effect consumers using `catchTag('WalletError', ...)` continue to work; new tags become opt-in handlers.
+- Promise consumers (`await wallet.shield(...)`) see the same rejection shape — the `_tag` field on the rejection now takes on more values.

--- a/src/Contract.ts
+++ b/src/Contract.ts
@@ -71,6 +71,33 @@ export class TxTimeoutError extends Data.TaggedError('TxTimeoutError')<{
   readonly message: string;
 }> {}
 
+/**
+ * Contract state lookup returned no result at the given address (and optionally
+ * at the given block height). Distinct from `ContractError` because consumers
+ * may want a "not yet deployed → redirect to create flow" UX rather than
+ * treating it as a crash.
+ *
+ * @since 0.6.3
+ * @category errors
+ */
+export class ContractStateNotFoundError extends Data.TaggedError('ContractStateNotFoundError')<{
+  readonly address: string;
+  readonly blockHeight?: number;
+  readonly message: string;
+}> {}
+
+/**
+ * `loadContract` was called without one of the required argument shapes:
+ * (1) `module` + `zkConfig`, (2) `path` (Node.js), or
+ * (3) `moduleUrl` + `zkConfigBaseUrl` (browser).
+ *
+ * @since 0.6.3
+ * @category errors
+ */
+export class ContractLoadArgsError extends Data.TaggedError('ContractLoadArgsError')<{
+  readonly message: string;
+}> {}
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -470,10 +497,10 @@ export interface DeployedContract<
     /** Type-safe Effect action methods. */
     readonly actions: ToEffectActions<TActions>;
     call(action: TCircuits, ...args: unknown[]): Effect.Effect<CallResult, ContractError>;
-    getState(): Effect.Effect<unknown, ContractError>;
-    getStateAt(blockHeight: number): Effect.Effect<unknown, ContractError>;
-    ledgerState(): Effect.Effect<TLedger, ContractError>;
-    ledgerStateAt(blockHeight: number): Effect.Effect<TLedger, ContractError>;
+    getState(): Effect.Effect<unknown, ContractError | ContractStateNotFoundError>;
+    getStateAt(blockHeight: number): Effect.Effect<unknown, ContractError | ContractStateNotFoundError>;
+    ledgerState(): Effect.Effect<TLedger, ContractError | ContractStateNotFoundError>;
+    ledgerStateAt(blockHeight: number): Effect.Effect<TLedger, ContractError | ContractStateNotFoundError>;
     /** Watch parsed state as an Effect.Stream. */
     watchState(options?: WatchOptions): Stream.Stream<TLedger, ContractError>;
     /** Watch raw state as an Effect.Stream. */
@@ -522,10 +549,10 @@ export interface ReadonlyContract<TLedger = unknown> {
 
   /** Effect versions of read-only methods. */
   readonly effect: {
-    readState(address: string): Effect.Effect<TLedger, ContractError>;
-    readStateAt(address: string, blockHeight: number): Effect.Effect<TLedger, ContractError>;
-    readRawState(address: string): Effect.Effect<unknown, ContractError>;
-    readRawStateAt(address: string, blockHeight: number): Effect.Effect<unknown, ContractError>;
+    readState(address: string): Effect.Effect<TLedger, ContractError | ContractStateNotFoundError>;
+    readStateAt(address: string, blockHeight: number): Effect.Effect<TLedger, ContractError | ContractStateNotFoundError>;
+    readRawState(address: string): Effect.Effect<unknown, ContractError | ContractStateNotFoundError>;
+    readRawStateAt(address: string, blockHeight: number): Effect.Effect<unknown, ContractError | ContractStateNotFoundError>;
     watchState(address: string, options?: WatchOptions): Stream.Stream<TLedger, ContractError>;
     watchRawState(address: string, options?: WatchOptions): Stream.Stream<unknown, ContractError>;
   };
@@ -582,7 +609,7 @@ export function loadContractModuleEffect(
     networkConfig: { proofServer: string };
   },
   logging: boolean,
-): Effect.Effect<LoadedContractData, ContractError> {
+): Effect.Effect<LoadedContractData, ContractError | ContractLoadArgsError> {
   return Effect.tryPromise({
     try: async () => {
       let module: ContractModule;
@@ -603,12 +630,13 @@ export function loadContractModuleEffect(
         module = options.module;
         zkConfig = options.zkConfig;
       } else {
-        throw new Error(
-          'Contract loading requires one of: ' +
-          '(1) module + zkConfig, ' +
-          '(2) path (Node.js), or ' +
-          '(3) moduleUrl + zkConfigBaseUrl (browser)',
-        );
+        throw new ContractLoadArgsError({
+          message:
+            'Contract loading requires one of: ' +
+            '(1) module + zkConfig, ' +
+            '(2) path (Node.js), or ' +
+            '(3) moduleUrl + zkConfigBaseUrl (browser)',
+        });
       }
 
       const witnesses = options.witnesses ?? {};
@@ -646,10 +674,12 @@ export function loadContractModuleEffect(
       };
     },
     catch: (cause) =>
-      new ContractError({
-        cause,
-        message: `Failed to load contract: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof ContractLoadArgsError
+        ? cause
+        : new ContractError({
+            cause,
+            message: `Failed to load contract: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
@@ -913,28 +943,35 @@ function callContractEffect(
   });
 }
 
-function contractStateEffect(contractData: DeployedContractData): Effect.Effect<unknown, ContractError> {
+function contractStateEffect(
+  contractData: DeployedContractData,
+): Effect.Effect<unknown, ContractError | ContractStateNotFoundError> {
   const address = contractData.address;
   return Effect.tryPromise({
     try: async () => {
       const contractState = await contractData.providers.publicDataProvider.queryContractState(address);
       if (!contractState) {
-        throw new Error(`Contract state not found at ${address}`);
+        throw new ContractStateNotFoundError({
+          address,
+          message: `Contract state not found at ${address}`,
+        });
       }
       return contractState.data;
     },
     catch: (cause) =>
-      new ContractError({
-        cause,
-        message: `Failed to query contract state: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof ContractStateNotFoundError
+        ? cause
+        : new ContractError({
+            cause,
+            message: `Failed to query contract state: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
 function contractStateAtEffect(
   contractData: DeployedContractData,
   blockHeight: number,
-): Effect.Effect<unknown, ContractError> {
+): Effect.Effect<unknown, ContractError | ContractStateNotFoundError> {
   const address = contractData.address;
   return Effect.tryPromise({
     try: async () => {
@@ -943,19 +980,27 @@ function contractStateAtEffect(
         blockHeight,
       });
       if (!contractState) {
-        throw new Error(`Contract state not found at ${address} at block ${blockHeight}`);
+        throw new ContractStateNotFoundError({
+          address,
+          blockHeight,
+          message: `Contract state not found at ${address} at block ${blockHeight}`,
+        });
       }
       return contractState.data;
     },
     catch: (cause) =>
-      new ContractError({
-        cause,
-        message: `Failed to query contract state at block ${blockHeight}: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof ContractStateNotFoundError
+        ? cause
+        : new ContractError({
+            cause,
+            message: `Failed to query contract state at block ${blockHeight}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
-function ledgerStateEffect(contractData: DeployedContractData): Effect.Effect<unknown, ContractError> {
+function ledgerStateEffect(
+  contractData: DeployedContractData,
+): Effect.Effect<unknown, ContractError | ContractStateNotFoundError> {
   return contractStateEffect(contractData).pipe(
     Effect.map((data) => contractData.module.ledger(data)),
   );
@@ -964,7 +1009,7 @@ function ledgerStateEffect(contractData: DeployedContractData): Effect.Effect<un
 function ledgerStateAtEffect(
   contractData: DeployedContractData,
   blockHeight: number,
-): Effect.Effect<unknown, ContractError> {
+): Effect.Effect<unknown, ContractError | ContractStateNotFoundError> {
   return contractStateAtEffect(contractData, blockHeight).pipe(
     Effect.map((data) => contractData.module.ledger(data)),
   );
@@ -1028,7 +1073,7 @@ function readRawStateEffect(
   address: string,
   provider: PublicDataProvider,
   atBlock?: number,
-): Effect.Effect<unknown, ContractError> {
+): Effect.Effect<unknown, ContractError | ContractStateNotFoundError> {
   return Effect.tryPromise({
     try: async () => {
       const opts = atBlock !== undefined
@@ -1036,19 +1081,24 @@ function readRawStateEffect(
         : undefined;
       const contractState = await provider.queryContractState(address, opts);
       if (!contractState) {
-        throw new Error(
-          atBlock !== undefined
-            ? `Contract state not found at ${address} at block ${atBlock}`
-            : `Contract state not found at ${address}`,
-        );
+        throw new ContractStateNotFoundError({
+          address,
+          blockHeight: atBlock,
+          message:
+            atBlock !== undefined
+              ? `Contract state not found at ${address} at block ${atBlock}`
+              : `Contract state not found at ${address}`,
+        });
       }
       return contractState.data;
     },
     catch: (cause) =>
-      new ContractError({
-        cause,
-        message: `Failed to query contract state: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof ContractStateNotFoundError
+        ? cause
+        : new ContractError({
+            cause,
+            message: `Failed to query contract state: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
@@ -1062,7 +1112,7 @@ function readStateEffect<TLedger>(
   provider: PublicDataProvider,
   ledgerParser: LedgerParser<TLedger>,
   atBlock?: number,
-): Effect.Effect<TLedger, ContractError> {
+): Effect.Effect<TLedger, ContractError | ContractStateNotFoundError> {
   return readRawStateEffect(address, provider, atBlock).pipe(
     Effect.map((data) => ledgerParser(data)),
   );
@@ -1388,7 +1438,7 @@ export interface CreateContractOptions<M extends ContractModule = ContractModule
  */
 function createContractEffect<M extends ContractModule>(
   options: CreateContractOptions<M>,
-): Effect.Effect<LoadedContractFor<M>, ContractError> {
+): Effect.Effect<LoadedContractFor<M>, ContractError | ContractLoadArgsError> {
   const {
     walletProvider,
     midnightProvider,

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -55,6 +55,80 @@ export class WalletError extends Data.TaggedError('WalletError')<{
   readonly message: string;
 }> {}
 
+/**
+ * Seed → HDWallet → key-derivation failure. `phase: 'init'` covers
+ * `HDWallet.fromSeed` returning a non-`seedOk` variant (invalid seed bytes);
+ * `phase: 'derive'` covers `deriveKeysAt(0)` returning a non-`keysDerived`
+ * variant. Surfaces from `Wallet.fromSeed` and `Wallet.deriveAddress`.
+ *
+ * @since 0.6.3
+ * @category errors
+ */
+export class WalletKeyDerivationError extends Data.TaggedError('WalletKeyDerivationError')<{
+  readonly phase: 'init' | 'derive';
+  readonly cause?: unknown;
+  readonly message: string;
+}> {}
+
+/**
+ * Lace browser extension is unavailable.
+ * - `'not-installed'` — no Midnight DApp Connector found on `window` after the wait.
+ * - `'incompatible-version'` — Lace is present but lacks a required capability
+ *   (e.g. `makeTransfer`); upgrade Lace to a DApp-Connector ≥ 4.0 build.
+ *
+ * @since 0.6.3
+ * @category errors
+ */
+export class LaceUnavailableError extends Data.TaggedError('LaceUnavailableError')<{
+  readonly reason: 'not-installed' | 'incompatible-version';
+  readonly detail?: string;
+  readonly message: string;
+}> {}
+
+/**
+ * Lace's `balanceUnsealedTransaction` (or related Lace-side step in the browser
+ * transaction pipeline) rejected. `detail` carries the joined Lace `APIError`
+ * fields (`code`/`reason`/`type`/`message`) for diagnostics.
+ *
+ * @since 0.6.3
+ * @category errors
+ */
+export class LaceTransferError extends Data.TaggedError('LaceTransferError')<{
+  readonly operation: 'balance';
+  readonly detail: string;
+  readonly cause?: unknown;
+  readonly message: string;
+}> {}
+
+/**
+ * `ledger.Transaction.deserialize` failed on bytes returned by Lace. Typically
+ * indicates a serializer/runtime version skew between the SDK's ledger-v8 and
+ * Lace's. `bytesLength` is the size of the Lace-returned blob.
+ *
+ * @since 0.6.3
+ * @category errors
+ */
+export class TransactionDeserializeError extends Data.TaggedError('TransactionDeserializeError')<{
+  readonly bytesLength: number;
+  readonly cause?: unknown;
+  readonly message: string;
+}> {}
+
+/**
+ * No eligible NIGHT UTXOs to (de)register for DUST generation.
+ * Distinct from `WalletError` because it's a *precondition* failure —
+ * not an exception — and consumers typically surface UX like
+ * "faucet some NIGHT first" rather than treating it as a crash.
+ *
+ * @since 0.6.3
+ * @category errors
+ */
+export class DustRegistrationError extends Data.TaggedError('DustRegistrationError')<{
+  readonly direction: 'register' | 'deregister';
+  readonly reason: 'no-eligible-utxos';
+  readonly message: string;
+}> {}
+
 // =============================================================================
 // Types — Seed Wallet
 // =============================================================================
@@ -330,10 +404,10 @@ export interface ConnectedWallet {
   readonly effect: {
     getBalance(): Effect.Effect<WalletBalance, WalletError>;
     providers(): Effect.Effect<WalletProviders, WalletError>;
-    shield(amount: bigint, options?: ShieldOptions): Effect.Effect<ShieldResult, WalletError>;
-    unshield(amount: bigint, options?: ShieldOptions): Effect.Effect<ShieldResult, WalletError>;
-    registerDust(options?: RegisterDustOptions): Effect.Effect<RegisterDustResult, WalletError>;
-    deregisterDust(options?: RegisterDustOptions): Effect.Effect<RegisterDustResult, WalletError>;
+    shield(amount: bigint, options?: ShieldOptions): Effect.Effect<ShieldResult, WalletError | LaceUnavailableError>;
+    unshield(amount: bigint, options?: ShieldOptions): Effect.Effect<ShieldResult, WalletError | LaceUnavailableError>;
+    registerDust(options?: RegisterDustOptions): Effect.Effect<RegisterDustResult, WalletError | DustRegistrationError>;
+    deregisterDust(options?: RegisterDustOptions): Effect.Effect<RegisterDustResult, WalletError | DustRegistrationError>;
     close(): Effect.Effect<void, WalletError>;
   };
 }
@@ -517,7 +591,10 @@ function closeEffect(walletContext: WalletContext): Effect.Effect<void, WalletEr
   });
 }
 
-function initEffect(seed: string, networkConfig: NetworkConfig): Effect.Effect<WalletContext, WalletError> {
+function initEffect(
+  seed: string,
+  networkConfig: NetworkConfig,
+): Effect.Effect<WalletContext, WalletError | WalletKeyDerivationError> {
   return Effect.tryPromise({
     try: async () => {
       const seedBytes = hexToBytes(seed);
@@ -539,14 +616,26 @@ function initEffect(seed: string, networkConfig: NetworkConfig): Effect.Effect<W
       };
 
       const hdWallet = HDWallet.fromSeed(seedBytes);
-      if (hdWallet.type !== 'seedOk') throw new Error('Failed to initialize HDWallet');
+      if (hdWallet.type !== 'seedOk') {
+        throw new WalletKeyDerivationError({
+          phase: 'init',
+          cause: hdWallet,
+          message: `HDWallet.fromSeed returned non-seedOk variant: ${hdWallet.type}`,
+        });
+      }
 
       const derivationResult = hdWallet.hdWallet
         .selectAccount(0)
         .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
         .deriveKeysAt(0);
 
-      if (derivationResult.type !== 'keysDerived') throw new Error('Failed to derive keys');
+      if (derivationResult.type !== 'keysDerived') {
+        throw new WalletKeyDerivationError({
+          phase: 'derive',
+          cause: derivationResult,
+          message: `deriveKeysAt(0) returned non-keysDerived variant: ${derivationResult.type}`,
+        });
+      }
       hdWallet.hdWallet.clear();
 
       const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
@@ -571,10 +660,12 @@ function initEffect(seed: string, networkConfig: NetworkConfig): Effect.Effect<W
       return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore, networkId: networkConfig.networkId };
     },
     catch: (cause) =>
-      new WalletError({
-        cause,
-        message: `Failed to initialize wallet: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof WalletKeyDerivationError
+        ? cause
+        : new WalletError({
+            cause,
+            message: `Failed to initialize wallet: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
@@ -589,30 +680,47 @@ function waitForSyncEffect(walletContext: WalletContext): Effect.Effect<void, Wa
   }).pipe(Effect.asVoid);
 }
 
-function deriveAddressEffect(seed: string, networkId: string): Effect.Effect<string, WalletError> {
+function deriveAddressEffect(
+  seed: string,
+  networkId: string,
+): Effect.Effect<string, WalletError | WalletKeyDerivationError> {
   return Effect.try({
     try: () => {
       const seedBytes = hexToBytes(seed);
 
       const hdWallet = HDWallet.fromSeed(seedBytes);
-      if (hdWallet.type !== 'seedOk') throw new Error('Failed to initialize HDWallet');
+      if (hdWallet.type !== 'seedOk') {
+        throw new WalletKeyDerivationError({
+          phase: 'init',
+          cause: hdWallet,
+          message: `HDWallet.fromSeed returned non-seedOk variant: ${hdWallet.type}`,
+        });
+      }
 
       const derivationResult = hdWallet.hdWallet
         .selectAccount(0)
         .selectRoles([Roles.NightExternal])
         .deriveKeysAt(0);
 
-      if (derivationResult.type !== 'keysDerived') throw new Error('Failed to derive keys');
+      if (derivationResult.type !== 'keysDerived') {
+        throw new WalletKeyDerivationError({
+          phase: 'derive',
+          cause: derivationResult,
+          message: `deriveKeysAt(0) returned non-keysDerived variant: ${derivationResult.type}`,
+        });
+      }
       hdWallet.hdWallet.clear();
 
       const unshieldedKeystore = createKeystore(derivationResult.keys[Roles.NightExternal], networkId as 'undeployed');
       return unshieldedKeystore.getBech32Address().asString();
     },
     catch: (cause) =>
-      new WalletError({
-        cause,
-        message: `Failed to derive address: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof WalletKeyDerivationError
+        ? cause
+        : new WalletError({
+            cause,
+            message: `Failed to derive address: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
@@ -649,7 +757,9 @@ function isAvailableEffect(): Effect.Effect<boolean, never> {
   return Effect.sync(() => !!findInjectedWallet());
 }
 
-function waitForWalletEffect(timeout: number = 5000): Effect.Effect<InitialAPI, WalletError> {
+function waitForWalletEffect(
+  timeout: number = 5000,
+): Effect.Effect<InitialAPI, WalletError | LaceUnavailableError> {
   return Effect.tryPromise({
     try: async () => {
       const start = Date.now();
@@ -660,13 +770,18 @@ function waitForWalletEffect(timeout: number = 5000): Effect.Effect<InitialAPI, 
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
 
-      throw new Error('Lace wallet not found. Please install the Lace browser extension.');
+      throw new LaceUnavailableError({
+        reason: 'not-installed',
+        message: 'Lace wallet not found. Please install the Lace browser extension.',
+      });
     },
     catch: (cause) =>
-      new WalletError({
-        cause,
-        message: `Wallet not available: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof LaceUnavailableError
+        ? cause
+        : new WalletError({
+            cause,
+            message: `Wallet not available: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
@@ -676,7 +791,9 @@ function isVersionCompatible(version: string, required: string): boolean {
   return major >= requiredMajor;
 }
 
-function connectEffect(networkId: string = 'testnet'): Effect.Effect<WalletConnection, WalletError> {
+function connectEffect(
+  networkId: string = 'testnet',
+): Effect.Effect<WalletConnection, WalletError | LaceUnavailableError> {
   return Effect.gen(function* () {
     if (typeof window === 'undefined') {
       return yield* Effect.fail(
@@ -760,7 +877,7 @@ function getProvingProviderEffect(
 function balanceTxEffect(
   wallet: ConnectedAPI,
   tx: UnboundTransaction,
-): Effect.Effect<FinalizedTransaction, WalletError> {
+): Effect.Effect<FinalizedTransaction, WalletError | LaceTransferError | TransactionDeserializeError> {
   return Effect.tryPromise({
     try: async () => {
       const txBytes = tx.serialize();
@@ -779,7 +896,12 @@ function balanceTxEffect(
           err.message && `message=${err.message}`,
         ].filter(Boolean).join(', ') || JSON.stringify(e);
         console.error('[midday-sdk] Lace balanceUnsealedTransaction error:', e);
-        throw new Error(`Lace balanceUnsealedTransaction failed: ${details}`);
+        throw new LaceTransferError({
+          operation: 'balance',
+          detail: details,
+          cause: e,
+          message: `Lace balanceUnsealedTransaction failed: ${details}`,
+        });
       }
 
       const resultBytes = hexToBytes(result.tx);
@@ -791,14 +913,20 @@ function balanceTxEffect(
           resultBytes,
         ) as FinalizedTransaction;
       } catch (e) {
-        throw new Error(`Transaction.deserialize failed (${resultBytes.length} bytes): ${e instanceof Error ? e.message : JSON.stringify(e)}`);
+        throw new TransactionDeserializeError({
+          bytesLength: resultBytes.length,
+          cause: e,
+          message: `Transaction.deserialize failed (${resultBytes.length} bytes): ${e instanceof Error ? e.message : JSON.stringify(e)}`,
+        });
       }
     },
     catch: (cause) =>
-      new WalletError({
-        cause,
-        message: `Failed to balance transaction: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof LaceTransferError || cause instanceof TransactionDeserializeError
+        ? cause
+        : new WalletError({
+            cause,
+            message: `Failed to balance transaction: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
@@ -983,15 +1111,18 @@ function shieldFromBrowserEffect(
   direction: TransferDirection,
   amount: bigint,
   options?: ShieldOptions,
-): Effect.Effect<ShieldResult, WalletError> {
+): Effect.Effect<ShieldResult, WalletError | LaceUnavailableError> {
   return Effect.tryPromise({
     try: async () => {
       const tokenType = options?.tokenType ?? ledger.nativeToken().raw;
 
       if (typeof connection.wallet.makeTransfer !== 'function') {
-        throw new Error(
-          'Lace wallet does not expose makeTransfer. Upgrade Lace to a version that supports the Midnight DApp Connector ≥ 4.0.',
-        );
+        throw new LaceUnavailableError({
+          reason: 'incompatible-version',
+          detail: 'makeTransfer not exposed',
+          message:
+            'Lace wallet does not expose makeTransfer. Upgrade Lace to a version that supports the Midnight DApp Connector ≥ 4.0.',
+        });
       }
 
       const recipient = direction === 'shield'
@@ -1014,10 +1145,12 @@ function shieldFromBrowserEffect(
       return { txId: tx, amount };
     },
     catch: (cause) =>
-      new WalletError({
-        cause,
-        message: `Failed to ${direction} ${amount}: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof LaceUnavailableError
+        ? cause
+        : new WalletError({
+            cause,
+            message: `Failed to ${direction} ${amount}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
@@ -1031,7 +1164,7 @@ function registerDustFromSeedEffect(
   walletContext: WalletContext,
   direction: RegisterDirection,
   options?: RegisterDustOptions,
-): Effect.Effect<RegisterDustResult, WalletError> {
+): Effect.Effect<RegisterDustResult, WalletError | DustRegistrationError> {
   return Effect.tryPromise({
     try: async () => {
       const nativeTokenType = ledger.nativeToken().raw;
@@ -1059,11 +1192,14 @@ function registerDustFromSeedEffect(
       const targets: readonly unknown[] = options?.utxos ?? allCoins.filter(shouldInclude);
 
       if (targets.length === 0) {
-        throw new Error(
-          direction === 'register'
-            ? 'No unregistered NIGHT UTXOs to register. Faucet some NIGHT first, or they may already be registered.'
-            : 'No registered NIGHT UTXOs to deregister.',
-        );
+        throw new DustRegistrationError({
+          direction,
+          reason: 'no-eligible-utxos',
+          message:
+            direction === 'register'
+              ? 'No unregistered NIGHT UTXOs to register. Faucet some NIGHT first, or they may already be registered.'
+              : 'No registered NIGHT UTXOs to deregister.',
+        });
       }
 
       const verifyingKey = walletContext.unshieldedKeystore.getPublicKey();
@@ -1090,10 +1226,12 @@ function registerDustFromSeedEffect(
       return { txId, count: targets.length };
     },
     catch: (cause) =>
-      new WalletError({
-        cause,
-        message: `Failed to ${direction} DUST: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof DustRegistrationError
+        ? cause
+        : new WalletError({
+            cause,
+            message: `Failed to ${direction} DUST: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
@@ -1139,7 +1277,7 @@ function fromSeedEffect(
   seed: string,
   networkConfig: NetworkConfig,
   options?: FromSeedOptions,
-): Effect.Effect<ConnectedWallet, WalletError> {
+): Effect.Effect<ConnectedWallet, WalletError | WalletKeyDerivationError> {
   return Effect.gen(function* () {
     const walletContext = yield* initEffect(seed, networkConfig);
 
@@ -1156,7 +1294,9 @@ function fromSeedEffect(
   });
 }
 
-function fromBrowserEffect(networkId: string = 'testnet'): Effect.Effect<ConnectedWallet, WalletError> {
+function fromBrowserEffect(
+  networkId: string = 'testnet',
+): Effect.Effect<ConnectedWallet, WalletError | LaceUnavailableError> {
   return Effect.gen(function* () {
     const connection = yield* connectEffect(networkId);
     const address = connection.addresses.shieldedAddress;
@@ -1197,7 +1337,7 @@ function createConnectedWalletHandle(
     direction: TransferDirection,
     amount: bigint,
     options?: ShieldOptions,
-  ): Effect.Effect<ShieldResult, WalletError> =>
+  ): Effect.Effect<ShieldResult, WalletError | LaceUnavailableError> =>
     backend.type === 'seed'
       ? shieldFromSeedEffect(backend.context, direction, amount, options)
       : shieldFromBrowserEffect(backend.connection, direction, amount, options);
@@ -1205,7 +1345,7 @@ function createConnectedWalletHandle(
   const registerDustEff = (
     direction: RegisterDirection,
     options?: RegisterDustOptions,
-  ): Effect.Effect<RegisterDustResult, WalletError> =>
+  ): Effect.Effect<RegisterDustResult, WalletError | DustRegistrationError> =>
     backend.type === 'seed'
       ? registerDustFromSeedEffect(backend.context, direction, options)
       : registerDustFromBrowserEffect(backend.connection, direction, options);
@@ -1434,10 +1574,16 @@ export const effect = {
  * @category service
  */
 export interface WalletServiceImpl {
-  readonly init: (seed: string, networkConfig: NetworkConfig) => Effect.Effect<WalletContext, WalletError>;
+  readonly init: (
+    seed: string,
+    networkConfig: NetworkConfig,
+  ) => Effect.Effect<WalletContext, WalletError | WalletKeyDerivationError>;
   readonly waitForSync: (walletContext: WalletContext) => Effect.Effect<void, WalletError>;
   readonly close: (walletContext: WalletContext) => Effect.Effect<void, WalletError>;
-  readonly deriveAddress: (seed: string, networkId: string) => Effect.Effect<string, WalletError>;
+  readonly deriveAddress: (
+    seed: string,
+    networkId: string,
+  ) => Effect.Effect<string, WalletError | WalletKeyDerivationError>;
   readonly providers: (walletContext: WalletContext) => Effect.Effect<WalletProviders, WalletError>;
 }
 
@@ -1474,7 +1620,7 @@ export const WalletLive: Layer.Layer<WalletService> = Layer.succeed(WalletServic
  * @category service
  */
 export interface WalletConnectorServiceImpl {
-  readonly connect: (networkId?: string) => Effect.Effect<WalletConnection, WalletError>;
+  readonly connect: (networkId?: string) => Effect.Effect<WalletConnection, WalletError | LaceUnavailableError>;
   readonly isAvailable: () => Effect.Effect<boolean, never>;
   readonly disconnect: () => Effect.Effect<void, never>;
   readonly getProvingProvider: (
@@ -1521,7 +1667,7 @@ export interface WalletProviderServiceImpl {
   readonly balanceTx: (
     wallet: ConnectedAPI,
     tx: UnboundTransaction,
-  ) => Effect.Effect<FinalizedTransaction, WalletError>;
+  ) => Effect.Effect<FinalizedTransaction, WalletError | LaceTransferError | TransactionDeserializeError>;
   readonly submitTx: (wallet: ConnectedAPI, tx: FinalizedTransaction) => Effect.Effect<TransactionId, WalletError>;
 }
 

--- a/src/ZkConfig.ts
+++ b/src/ZkConfig.ts
@@ -58,6 +58,20 @@ export class ZkConfigError extends Data.TaggedError('ZkConfigError')<{
   readonly message: string;
 }> {}
 
+/**
+ * HTTP fetch for a ZK key returned a non-ok response (`!response.ok`).
+ *
+ * @since 0.6.3
+ * @category errors
+ */
+export class ZkConfigFetchError extends Data.TaggedError('ZkConfigFetchError')<{
+  readonly url: string;
+  readonly status: number;
+  readonly statusText: string;
+  readonly cause?: unknown;
+  readonly message: string;
+}> {}
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -164,28 +178,35 @@ function isBuiltinCircuit(circuitId: string): boolean {
 function fetchBytesEffect(
   provider: HttpZkConfigProviderData,
   url: string,
-): Effect.Effect<Uint8Array, ZkConfigError> {
+): Effect.Effect<Uint8Array, ZkConfigError | ZkConfigFetchError> {
   return Effect.tryPromise({
     try: async () => {
       const response = await provider.fetchFn(url);
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+        throw new ZkConfigFetchError({
+          url,
+          status: response.status,
+          statusText: response.statusText,
+          message: `HTTP ${response.status} ${response.statusText} fetching ${url}`,
+        });
       }
       const buffer = await response.arrayBuffer();
       return new Uint8Array(buffer);
     },
     catch: (cause) =>
-      new ZkConfigError({
-        cause,
-        message: `Failed to fetch ZK config from ${url}: ${cause instanceof Error ? cause.message : String(cause)}`,
-      }),
+      cause instanceof ZkConfigFetchError
+        ? cause
+        : new ZkConfigError({
+            cause,
+            message: `Failed to fetch ZK config from ${url}: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
   });
 }
 
 function getZKIREffect(
   provider: HttpZkConfigProviderData,
   circuitId: string,
-): Effect.Effect<ZKIR, ZkConfigError> {
+): Effect.Effect<ZKIR, ZkConfigError | ZkConfigFetchError> {
   if (isBuiltinCircuit(circuitId)) {
     return Effect.fail(new ZkConfigError({ cause: null, message: `Built-in circuit ${circuitId} — skipping HTTP fetch` }));
   }
@@ -203,7 +224,7 @@ function getZKIREffect(
 function getProverKeyEffect(
   provider: HttpZkConfigProviderData,
   circuitId: string,
-): Effect.Effect<ProverKey, ZkConfigError> {
+): Effect.Effect<ProverKey, ZkConfigError | ZkConfigFetchError> {
   if (isBuiltinCircuit(circuitId)) {
     return Effect.fail(new ZkConfigError({ cause: null, message: `Built-in circuit ${circuitId} — skipping HTTP fetch` }));
   }
@@ -221,7 +242,7 @@ function getProverKeyEffect(
 function getVerifierKeyEffect(
   provider: HttpZkConfigProviderData,
   circuitId: string,
-): Effect.Effect<VerifierKey, ZkConfigError> {
+): Effect.Effect<VerifierKey, ZkConfigError | ZkConfigFetchError> {
   if (isBuiltinCircuit(circuitId)) {
     return Effect.fail(new ZkConfigError({ cause: null, message: `Built-in circuit ${circuitId} — skipping HTTP fetch` }));
   }
@@ -402,15 +423,15 @@ export interface ZkConfigServiceImpl {
   readonly getZKIR: (
     provider: HttpZkConfigProviderData,
     circuitId: string,
-  ) => Effect.Effect<ZKIR, ZkConfigError>;
+  ) => Effect.Effect<ZKIR, ZkConfigError | ZkConfigFetchError>;
   readonly getProverKey: (
     provider: HttpZkConfigProviderData,
     circuitId: string,
-  ) => Effect.Effect<ProverKey, ZkConfigError>;
+  ) => Effect.Effect<ProverKey, ZkConfigError | ZkConfigFetchError>;
   readonly getVerifierKey: (
     provider: HttpZkConfigProviderData,
     circuitId: string,
-  ) => Effect.Effect<VerifierKey, ZkConfigError>;
+  ) => Effect.Effect<VerifierKey, ZkConfigError | ZkConfigFetchError>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces 14 raw \`throw new Error(...)\` calls across \`Wallet.ts\` (9), \`Contract.ts\` (4), and \`ZkConfig.ts\` (1) with 8 new \`Data.TaggedError\` subtypes. Existing umbrella errors (\`WalletError\`, \`ContractError\`, \`ZkConfigError\`) stay as catch-alls for genuinely-unclassified upstream failures.

| Module | New error tag | Replaces |
|---|---|---|
| Wallet | \`WalletKeyDerivationError\` (\`phase: 'init' \| 'derive'\`) | HDWallet init + key-derivation throws (×4) |
| Wallet | \`LaceUnavailableError\` (\`reason: 'not-installed' \| 'incompatible-version'\`) | Lace-not-installed + \`makeTransfer\`-not-exposed (×2) |
| Wallet | \`LaceTransferError\` (\`operation: 'balance'\`) | \`balanceUnsealedTransaction\` failure (×1) |
| Wallet | \`TransactionDeserializeError\` (\`bytesLength\`) | \`ledger.Transaction.deserialize\` failure (×1) |
| Wallet | \`DustRegistrationError\` (\`direction\`, \`reason\`) | no-eligible-UTXOs precondition (×1) |
| Contract | \`ContractStateNotFoundError\` (\`address\`, optional \`blockHeight\`) | \`queryContractState\` returned null (×3) |
| Contract | \`ContractLoadArgsError\` | \`loadContract\` arg-shape validation (×1) |
| ZkConfig | \`ZkConfigFetchError\` (\`url\`, \`status\`, \`statusText\`) | HTTP \`!response.ok\` (×1) |

## Non-breaking

- Effect consumers using \`catchAll\` or no explicit error annotation: unaffected.
- Effect consumers using \`catchTag('WalletError', ...)\` etc.: continue to work; new tags become opt-in handlers via \`catchTag\` for the new tag names.
- Promise consumers (\`await wallet.shield(...)\`) see the same rejection shape — \`_tag\` now takes on more values.

\`Effect.Effect<X, WalletError>\` signatures widen additively to unions (e.g. \`Effect.Effect<ShieldResult, WalletError | LaceUnavailableError>\`). The internal pattern in each \`Effect.try\`/\`Effect.tryPromise\` is \`catch: (cause) => cause instanceof NewTag ? cause : new WalletError({...})\`, so tagged errors pass through and unrecognized errors keep their catch-all wrapping.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm build\` — exit 0
- [x] \`grep -c "throw new Error" src/{Wallet,Contract,ZkConfig}.ts\` — all 0
- [ ] CI \`build\` + \`e2e\` green on this PR

## Not in scope

- \`Utils.ts\` (8 raw throws) and \`Hash.ts\` (1) deliberately untouched — these are sync input-validation helpers; tagging them adds API surface without enabling new recovery paths, and they're already caught into surrounding tagged errors when called from inside Effect bodies.
- No new tests in this pass; the new throw paths need extension-state mocks (Lace absence, mocked HDWallet) and the catch-passthrough logic is mechanical enough to read. If you want per-tag coverage, separate follow-up.